### PR TITLE
Made global variables extern in headers

### DIFF
--- a/runtime/cilk2c.h
+++ b/runtime/cilk2c.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 // mainly used by invoke-main.c
-CHEETAH_INTERNAL unsigned long cilkrts_zero;
+extern CHEETAH_INTERNAL unsigned long cilkrts_zero;
 
 // These functions are mostly inlined by the compiler, except for
 // __cilkrts_leave_frame.  However, their implementations are also

--- a/runtime/init.h
+++ b/runtime/init.h
@@ -9,6 +9,6 @@ CHEETAH_INTERNAL void __cilkrts_cleanup(global_state *);
 CHEETAH_INTERNAL_NORETURN void invoke_main();
 CHEETAH_INTERNAL void parse_environment();
 CHEETAH_INTERNAL long env_get_int(char const *var);
-CHEETAH_INTERNAL unsigned cilkg_nproc;
+extern CHEETAH_INTERNAL unsigned cilkg_nproc;
 
 #endif /* _CILK_INIT_H */


### PR DESCRIPTION
This fixes duplicate symbol build errors