### PR TITLE
Simplify static initialization of worker structures

### DIFF
--- a/runtime/cilk2c.c
+++ b/runtime/cilk2c.c
@@ -169,20 +169,13 @@ void __cilkrts_sync(__cilkrts_stack_frame *sf) {
 ///////////////////////////////////////////////////////////////////////////
 /// Methods for handling extensions
 
-static inline __cilkrts_worker *get_worker_or_default(void) {
-    __cilkrts_worker *w = __cilkrts_get_tls_worker();
-    if (NULL == w)
-        w = &default_worker;
-    return w;
-}
-
 void __cilkrts_register_extension(void *extension) {
     __cilkrts_use_extension = true;
-    __cilkrts_worker *w = get_worker_or_default();
+    __cilkrts_worker *w = __cilkrts_get_tls_worker();
     w->extension = extension;
 }
 
 void *__cilkrts_get_extension(void) {
-    __cilkrts_worker *w = get_worker_or_default();
+    __cilkrts_worker *w = __cilkrts_get_tls_worker();
     return w->extension;
 }

--- a/runtime/global.c
+++ b/runtime/global.c
@@ -23,7 +23,6 @@ typedef cpuset_t cpu_set_t;
 
 global_state *default_cilkrts;
 
-CHEETAH_INTERNAL
 __cilkrts_worker default_worker = {.self = 0,
                                    .hyper_table = NULL,
                                    .g = NULL,

--- a/runtime/local-reducer-api.c
+++ b/runtime/local-reducer-api.c
@@ -15,7 +15,7 @@ void __cilkrts_reducer_register(void *key, size_t size,
     struct bucket b = {.key = (uintptr_t)key,
                        .value = {.view = key, .reduce_fn = reduce}};
     bool success = insert_hyperobject(table, b);
-    CILK_ASSERT(get_worker_or_default(),
+    CILK_ASSERT(__cilkrts_get_tls_worker(),
                 success && "Failed to register reducer.");
     (void)success;
 }
@@ -35,8 +35,8 @@ void __cilkrts_reducer_register_64(void *key, uint64_t size,
 void __cilkrts_reducer_unregister(void *key) {
     struct local_hyper_table *table = get_hyper_table();
     bool success = remove_hyperobject(table, (uintptr_t)key);
-    /* CILK_ASSERT(get_worker_or_default(), success && "Failed to unregister
-     * reducer."); */
+    /* CILK_ASSERT(__cilkrts_get_tls_worker(), */
+    /*             success && "Failed to unregister reducer."); */
     (void)success;
 }
 

--- a/runtime/local-reducer-api.h
+++ b/runtime/local-reducer-api.h
@@ -1,14 +1,9 @@
 #ifndef _LOCAL_REDUCER_API_H
 #define _LOCAL_REDUCER_API_H
 
+#include "cilk-internal.h"
+#include "global.h"
 #include "local-hypertable.h"
-
-static inline __cilkrts_worker *get_worker_or_default(void) {
-    __cilkrts_worker *w = __cilkrts_get_tls_worker();
-    if (NULL == w)
-        w = default_cilkrts->workers[0];
-    return w;
-}
 
 static inline struct local_hyper_table *
 get_local_hyper_table(__cilkrts_worker *w) {

--- a/runtime/scheduler.c
+++ b/runtime/scheduler.c
@@ -41,7 +41,7 @@ bool __cilkrts_use_extension = false;
 bool __cilkrts_need_to_cilkify = true;
 
 // TLS pointer to the current worker structure.
-__thread __cilkrts_worker *__cilkrts_tls_worker = NULL;
+__thread __cilkrts_worker *__cilkrts_tls_worker = &default_worker;
 
 // TLS pointer to the current fiber header.
 //


### PR DESCRIPTION
Statically initialize all __cilkrts_tls_worker variables to point to default_worker.  This change simplifies the logic to initialize global reducer variables before the runtime itself has been initialized.