### PR TITLE
Use the stack guard page provided by the kernel

### DIFF
--- a/runtime/cilk-internal.h
+++ b/runtime/cilk-internal.h
@@ -47,7 +47,7 @@ extern bool __cilkrts_use_extension;
 #define USE_EXTENSION false
 #endif
 extern __thread __cilkrts_worker *__cilkrts_tls_worker;
-extern __thread struct fiber_header *__cilkrts_current_fh;
+extern __thread struct cilk_fiber *__cilkrts_current_fh;
 extern bool __cilkrts_need_to_cilkify;
 
 static inline __attribute__((always_inline)) __cilkrts_worker *

--- a/runtime/cilk2c_inlined.c
+++ b/runtime/cilk2c_inlined.c
@@ -110,7 +110,7 @@ __cilkrts_enter_frame(__cilkrts_stack_frame *sf) {
 
     sf->magic = frame_magic;
 
-    struct fiber_header *fh = __cilkrts_current_fh;
+    struct cilk_fiber *fh = __cilkrts_current_fh;
     sf->fh = fh;
     sf->call_parent = fh->current_stack_frame;
     fh->current_stack_frame = sf;
@@ -130,7 +130,7 @@ __cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf) {
     sf->flags = 0;
     sf->magic = frame_magic;
 
-    struct fiber_header *fh = __cilkrts_current_fh;
+    struct cilk_fiber *fh = __cilkrts_current_fh;
     sf->fh = fh;
     sf->call_parent = fh->current_stack_frame;
     fh->current_stack_frame = sf;

--- a/runtime/fiber-header.h
+++ b/runtime/fiber-header.h
@@ -1,15 +1,14 @@
 #ifndef _FIBER_HEADER_H
 #define _FIBER_HEADER_H
 
-#include <stdio.h>
-
 #include "rts-config.h"
 
 struct __cilkrts_worker;
 struct __cilkrts_stack_frame;
 
 // Structure inserted at the top of a fiber, to implement fiber-local storage.
-struct fiber_header {
+// The stack begins just below this structure.  See sysdep_get_stack_start().
+struct cilk_fiber {
     // Worker currently executing on the fiber.
     struct __cilkrts_worker *worker;
     // Current stack frame executing on the fiber.
@@ -22,6 +21,14 @@ struct fiber_header {
     // Pointer to AddressSanitizer's fake stack associated with this fiber, when
     // AddressSanitizer is being used.
     void *fake_stack_save;
+
+    // These next two words are for internal library use and are
+    // constant for the life of this structure.
+    char *alloc_low;         // lowest byte of mapped region
+    char *stack_low;         // lowest byte of stack region
+
+    // Three unused words remain 64 bit systems with 64 byte cache lines.
+
 } __attribute__((aligned(CILK_CACHE_LINE)));
 
 #endif // _FIBER_HEADER_H

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1,4 +1,4 @@
-#ifndef _GNU_SOURCE
+#if defined __linux__ && !defined _GNU_SOURCE
 #define _GNU_SOURCE // For RTLD_DEFAULT from dlfcn.h
 #endif
 
@@ -17,19 +17,38 @@
 #include "fiber-header.h"
 #include "init.h"
 
-#include <string.h> /* DEBUG */
+#include <string.h> /* memset() */
+
+/* Set up flags for mmap to allocate a stack region.
+
+   Darwin does not have any special support for mapping stacks and
+   defines neither MAP_STACK nor MAP_GROWSDOWN.
+
+   On FreeBSD MAP_STACK requests a region that grows on demand and has
+   a guard page at the low end.  MAP_GROWSDOWN is not defined.
+   Strictly speaking, there are security.bsd.stack_guard_page guard
+   pages.  The default value of this tunable is 1.
+
+   On OpenBSD MAP_STACK designates the region as a legal stack location.
+   With some kernel configurations a program is not allowed to run on a
+   stack that has not been allocated with this flag.   MAP_GROWSDOWN is
+   not defined.
+
+   On Linux MAP_STACK does nothing and is provided for BSD compatibility.
+   MAP_GROWSDOWN has the same meaning as FreeBSD's MAP_STACK.  There is
+   a single guard page at the bottom of the region, and stack_guard_gap
+   unmapped pages between any two stacks. */
 
 #ifndef MAP_GROWSDOWN
-/* MAP_GROWSDOWN is implied on BSD */
 #define MAP_GROWSDOWN 0
 #endif
-#ifndef MAP_STACK
-/* MAP_STACK is not available on Darwin */
-#define MAP_STACK 0
+#ifdef MAP_STACK
+#define MAP_STACK_FLAGS \
+  (MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK | MAP_GROWSDOWN)
+#else
+#define MAP_STACK_FLAGS \
+  (MAP_PRIVATE | MAP_ANONYMOUS)
 #endif
-
-#define LOW_GUARD_PAGES 1
-#define HIGH_GUARD_PAGES 1
 
 //===============================================================
 // This file maintains fiber-related function that requires
@@ -263,11 +282,7 @@ static void make_stack(struct cilk_fiber *f, size_t stack_size) {
     const size_t page_size = 1U << page_shift;
 
     size_t stack_pages = (stack_size + page_size - 1) >> cheetah_page_shift;
-    // Overallocate pages so we can get a stack aligned to stack_size.
-    stack_pages += LOW_GUARD_PAGES + HIGH_GUARD_PAGES;
 
-    /* Stacks must be at least MIN_NUM_PAGES_PER_STACK pages,
-       a count which includes two guard pages. */
     if (stack_pages < MIN_NUM_PAGES_PER_STACK) {
         stack_pages = MIN_NUM_PAGES_PER_STACK;
     } else if (stack_pages > MAX_NUM_PAGES_PER_STACK) {
@@ -275,7 +290,7 @@ static void make_stack(struct cilk_fiber *f, size_t stack_size) {
     }
     char *alloc_low = (char *)mmap(
         0, stack_pages * page_size, PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK | MAP_GROWSDOWN, -1, 0);
+        MAP_STACK_FLAGS, -1, 0);
     if (MAP_FAILED == alloc_low) {
         cilkrts_bug(NULL, "Cilk: stack mmap failed");
         /* Currently unreached.  TODO: Investigate more graceful
@@ -283,34 +298,29 @@ static void make_stack(struct cilk_fiber *f, size_t stack_size) {
         f->alloc_low = NULL;
         f->stack_low = NULL;
         f->stack_high = NULL;
-        f->alloc_high = NULL;
         return;
     }
-    char *alloc_high = alloc_low + stack_pages * page_size;
-    // Round down to the previous stack size.
-    char *stack_high = alloc_high - page_size;
+    char *stack_high = alloc_low + stack_pages * page_size;
     char *stack_low = alloc_low + page_size;
-    // mprotect guard pages.
-    mprotect(alloc_low, page_size, PROT_NONE);
-    mprotect(stack_high, page_size, PROT_NONE);
+#ifndef MAP_STACK
+    (void)mprotect(alloc_low, page_size, PROT_NONE);
+#endif
     f->alloc_low = alloc_low;
     f->stack_low = stack_low;
     f->stack_high = stack_high;
-    f->alloc_high = alloc_high;
     if (DEBUG_ENABLED(MEMORY_SLOW))
-        memset(stack_low, 0x11, stack_size);
+        memset(stack_low, 0x11, stack_high - stack_low);
 }
 
 static void free_stack(struct cilk_fiber *f) {
     if (f->alloc_low) {
         if (DEBUG_ENABLED(MEMORY_SLOW))
             memset(f->stack_low, 0xbb, f->stack_high - f->stack_low);
-        if (munmap(f->alloc_low, f->alloc_high - f->alloc_low) < 0)
+        if (munmap(f->alloc_low, f->stack_high - f->alloc_low) < 0)
             cilkrts_bug(NULL, "Cilk: stack munmap failed");
         f->alloc_low = NULL;
         f->stack_low = NULL;
         f->stack_high = NULL;
-        f->alloc_high = NULL;
     }
 }
 
@@ -318,7 +328,6 @@ static void fiber_init(struct cilk_fiber *fiber) {
     fiber->alloc_low = NULL;
     fiber->stack_low = NULL;
     fiber->stack_high = NULL;
-    fiber->alloc_high = NULL;
 }
 
 

--- a/runtime/fiber.h
+++ b/runtime/fiber.h
@@ -41,7 +41,6 @@ struct cilk_fiber {
     char *alloc_low;         // first byte of mmap-ed region
     char *stack_low;         // lowest usable byte of stack
     char *stack_high;        // one byte above highest usable byte of stack
-    char *alloc_high;        // last byte of mmap-ed region
 };
 
 static inline struct fiber_header *

--- a/runtime/frame.h
+++ b/runtime/frame.h
@@ -28,7 +28,7 @@ struct __cilkrts_stack_frame {
     // This pointer is redundant with the __cilkrts_current_fh TLS variable, but
     // accessing TLS is expensive on some systems, such as macOS.  It is
     // therefore faster to use this variable when possible.
-    struct fiber_header *fh;
+    struct cilk_fiber *fh;
 
     // call_parent points to the __cilkrts_stack_frame of the closest ancestor
     // spawning function, including spawn helpers, of this frame.  For each

--- a/runtime/personality.c
+++ b/runtime/personality.c
@@ -210,7 +210,7 @@ _Unwind_Reason_Code __cilk_personality_internal(
         return std_lib_personality(version, actions, exception_class, ue_header,
                                    context);
 
-    struct fiber_header *fh = __cilkrts_current_fh;
+    struct cilk_fiber *fh = __cilkrts_current_fh;
     __cilkrts_worker *w = fh->worker;
     CILK_ASSERT_POINTER_EQUAL(w, w, __cilkrts_get_tls_worker());
     __cilkrts_stack_frame *sf = fh->current_stack_frame;

--- a/runtime/rts-config.h
+++ b/runtime/rts-config.h
@@ -48,7 +48,7 @@
 
 #define ENABLE_WORKER_PINNING 0
 
-#define MIN_NUM_PAGES_PER_STACK 4
+#define MIN_NUM_PAGES_PER_STACK 4 // must be greater than 1
 #define MAX_NUM_PAGES_PER_STACK 2000
 
 #define DEFAULT_NPROC 0 // 0 for # of cores available

--- a/runtime/worker.h
+++ b/runtime/worker.h
@@ -7,7 +7,6 @@ struct __cilkrts_stack_frame;
 struct local_state;
 struct global_state;
 struct local_hyper_table;
-struct fiber_header;
 
 enum __cilkrts_worker_state {
     WORKER_IDLE = 10,


### PR DESCRIPTION
FreeBSD and Linux provide a guard page when (MAP_GROWSDOWN|MAP_STACK) is used.  There is no need to explicitly call mmap and doing so may cause unnecessary memory allocation.  The guard page at high end of address range is probably not useful.  On Linux the page above a MAP_GROWSDOWN region is likely to be unmapped because stack regions are spaced 1 MB apart by default.