### PR TITLE
Use prototypes for functions with no arguments

### DIFF
--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -56,7 +56,7 @@ extern CHEETAH_INTERNAL unsigned int debug_level;
 
 CHEETAH_INTERNAL void set_alert_level(unsigned int);
 CHEETAH_INTERNAL void set_debug_level(unsigned int);
-CHEETAH_INTERNAL void flush_alert_log();
+CHEETAH_INTERNAL void flush_alert_log(void);
 
 __attribute__((__format__(__printf__, 2, 3))) CHEETAH_INTERNAL_NORETURN void
 cilkrts_bug(struct __cilkrts_worker *w, const char *fmt, ...);

--- a/runtime/fiber.h
+++ b/runtime/fiber.h
@@ -167,7 +167,7 @@ CHEETAH_INTERNAL int in_fiber(struct cilk_fiber *, void *);
 
 #if CILK_ENABLE_ASAN_HOOKS
 void sanitizer_start_switch_fiber(struct cilk_fiber *fiber);
-void sanitizer_finish_switch_fiber();
+void sanitizer_finish_switch_fiber(void);
 CHEETAH_INTERNAL void sanitizer_poison_fiber(struct cilk_fiber *fiber);
 CHEETAH_INTERNAL void sanitizer_unpoison_fiber(struct cilk_fiber *fiber);
 #else

--- a/runtime/local-hypertable.h
+++ b/runtime/local-hypertable.h
@@ -35,7 +35,7 @@ typedef struct local_hyper_table {
     struct bucket *buckets;
 } hyper_table;
 
-hyper_table *__cilkrts_local_hyper_table_alloc();
+hyper_table *__cilkrts_local_hyper_table_alloc(void);
 CHEETAH_INTERNAL
 void local_hyper_table_free(hyper_table *table);
 


### PR DESCRIPTION
A declaration `void f()` is treated like `void f(...)` (which used to be a legitimate declaration if it isn't now) and calls to the function use a varargs calling convention.