### PR TITLE
Pass stack_frame to hyperobject lookup

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -92,8 +92,12 @@ endif()
 
 # Add compile flags for Cheetah-runtime compilation that should be
 # excluded from bitcode compilation
-if (CHEETAH_HAS_MAVX_FLAG)
-  list(APPEND CHEETAH_COMPILE_FLAGS -mavx)
+if (DEFINED CHEETAH_ARCH_FLAGS)
+  list(APPEND CHEETAH_COMPILE_FLAGS ${CHEETAH_ARCH_FLAGS})
+else()
+  if (CHEETAH_HAS_MAVX_FLAG)
+    list(APPEND CHEETAH_COMPILE_FLAGS -mavx)
+  endif()
 endif()
 
 if (APPLE)

--- a/runtime/cilk2c_inlined.c
+++ b/runtime/cilk2c_inlined.c
@@ -52,9 +52,12 @@ void *__cilkrts_reducer_lookup_in_frame(struct __cilkrts_stack_frame *frame,
                                         void *identity_ptr, void *reduce_ptr) {
     // If we're outside a cilkified region, then the key is the view.
     // The null test will normally be optimized out.
-    if (!frame)
-        return key;
-    struct local_hyper_table *table = get_local_hyper_table(frame->fh->worker);
+    __cilkrts_worker *w;
+    if (frame)
+      w = frame->fh->worker; // Never null
+    else if (!(w = __cilkrts_get_tls_worker()))
+      return key;
+    struct local_hyper_table *table = get_local_hyper_table(w);
     struct bucket *b = find_hyperobject(table, (uintptr_t)key);
     if (__builtin_expect(!!b, true)) {
         // Return the existing view.

--- a/runtime/cilk2c_inlined.c
+++ b/runtime/cilk2c_inlined.c
@@ -47,26 +47,9 @@ unsigned __cilkrts_get_worker_number(void) {
     return 0;
 }
 
-void *__cilkrts_reducer_lookup(void *key, size_t size,
-                               void *identity_ptr, void *reduce_ptr) {
-    // If we're outside a cilkified region, then the key is the view.
-    if (__cilkrts_need_to_cilkify)
-        return key;
-    struct local_hyper_table *table = get_hyper_table();
-    struct bucket *b = find_hyperobject(table, (uintptr_t)key);
-    if (__builtin_expect(!!b, true)) {
-        // Return the existing view.
-        return b->value.view;
-    }
-
-    return __cilkrts_insert_new_view(table, (uintptr_t)key, size,
-                                     (__cilk_identity_fn)identity_ptr,
-                                     (__cilk_reduce_fn)reduce_ptr);
-}
-
-void *__cilkrts_reducer_lookup_frame(struct __cilkrts_stack_frame *frame,
-                                     void *key, size_t size,
-                                     void *identity_ptr, void *reduce_ptr) {
+void *__cilkrts_reducer_lookup_in_frame(struct __cilkrts_stack_frame *frame,
+                                        void *key, size_t size,
+                                        void *identity_ptr, void *reduce_ptr) {
     // If we're outside a cilkified region, then the key is the view.
     // The null test will normally be optimized out.
     if (!frame)

--- a/runtime/local-reducer-api.h
+++ b/runtime/local-reducer-api.h
@@ -7,7 +7,7 @@
 
 static inline struct local_hyper_table *
 get_local_hyper_table(__cilkrts_worker *w) {
-    if (NULL == w->hyper_table) {
+    if (__builtin_expect(NULL == w->hyper_table, 0)) {
         w->hyper_table = __cilkrts_local_hyper_table_alloc();
     }
     return w->hyper_table;


### PR DESCRIPTION
This pairs with a compiler change to pass a pointer to the `stack_frame` object to the runtime when looking up a view.  If a hyperobject is referenced outside of a Cilk function the pointer will be null and TLS will be used.