### PR TITLE
allow handcomp_test compilation configuration from terminal

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,31 +1,30 @@
-COMPILER_BASE=
+COMPILER_BASE?=
 CC=$(COMPILER_BASE)clang
 CXX=$(COMPILER_BASE)clang++
 LINK_CC=$(CC)
 LLVM_LINK=$(COMPILER_BASE)llvm-link
 LLVM_CONFIG=$(COMPILER_BASE)llvm-config
 #
-ABI_DEF=-DOPENCILK_ABI
+ABI_DEF?=-DOPENCILK_ABI
 # If use cheetah
-RTS_DIR=../runtime
-RTS_LIB=libopencilk
-RTS_C_PERSONALITY_LIB=libopencilk-personality-c
-RTS_CXX_PERSONALITY_LIB=libopencilk-personality-cpp
-RTS_PEDIGREE_LIB=libopencilk-pedigrees
+RTS_DIR?=../runtime
+RTS_LIB?=libopencilk
+RTS_C_PERSONALITY_LIB?=libopencilk-personality-c
+RTS_CXX_PERSONALITY_LIB?=libopencilk-personality-cpp
+RTS_PEDIGREE_LIB?=libopencilk-pedigrees
 
 # All runtime libraries and associated files will be placed in
 # `/oath/to/cheetah/lib/<target-triple>`, so that the compiler can easily find
 # all of those files using the flag --opencilk-resource-dir=/path/to/cheetah.
-RTS_LIBDIR_NAME=lib/$(shell $(LLVM_CONFIG) --host-target)
-RESOURCE_DIR=$(PWD)
-RTS_LIBDIR=$(RESOURCE_DIR)/$(RTS_LIBDIR_NAME)
-RTS_OPT=-fopencilk --opencilk-resource-dir=$(RESOURCE_DIR)
+RTS_LIBDIR_NAME?=lib/$(shell $(LLVM_CONFIG) --host-target)
+RESOURCE_DIR?=$(PWD)
+RTS_LIBDIR?=$(RESOURCE_DIR)/$(RTS_LIBDIR_NAME)
+RTS_OPT?=-fopencilk --opencilk-resource-dir=$(RESOURCE_DIR)
 #RTS_LIB_FLAG=-lcheetah
 
 #ARCH = -mavx
-OPT = -O3
-DBG = -g3
+OPT ?= -O3
+DBG ?= -g3
 # A large number of processors, system-dependent
 # TODO: There should be an additional value meaning "all cores"
-MANYPROC = 8
-
+MANYPROC ?= 8

--- a/handcomp_test/Makefile
+++ b/handcomp_test/Makefile
@@ -7,7 +7,7 @@ OBJS = $(patsubst %.c,%.o,$(SRCS))
 DEFINES = $(ABI_DEF)
 
 TESTS   = cilksort fib mm_dac nqueens
-OPTIONS = $(OPT) $(ARCH) $(DBG) -Wall $(DEFINES) -fno-omit-frame-pointer
+OPTIONS = $(OPT) $(ARCH) $(DBG) -Wall $(DEFINES) -fno-omit-frame-pointer $(CFLAGS)
 # dynamic linking
 # RTS_DLIBS = -L../runtime -Wl,-rpath -Wl,../runtime -lopencilk
 # RTS_LIBS = ../runtime/$(RTS_LIB).so


### PR DESCRIPTION
It is useful to be able to compile multiple copies of the runtime and multiple copies of handcomp_test from a script while using the same source directories (e.g. a version of the runtime that sleeps and a version that doesn't sleep). This change makes some changes to the default config.mk and handcomp_tests/Makefile to make these builds more configurable from the terminal.
