### PR TITLE
Allow for override of architecture flags in runtime cmake

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -92,8 +92,12 @@ endif()
 
 # Add compile flags for Cheetah-runtime compilation that should be
 # excluded from bitcode compilation
-if (CHEETAH_HAS_MAVX_FLAG)
-  list(APPEND CHEETAH_COMPILE_FLAGS -mavx)
+if (DEFINED CHEETAH_ARCH_FLAGS)
+  list(APPEND CHEETAH_COMPILE_FLAGS ${CHEETAH_ARCH_FLAGS})
+else()
+  if (CHEETAH_HAS_MAVX_FLAG)
+    list(APPEND CHEETAH_COMPILE_FLAGS -mavx)
+  endif()
 endif()
 
 if (APPLE)


### PR DESCRIPTION
This change makes it easier to modify the CPU architecture related flags, making it easier for custom builds to either target specific CPU instructions or to not target specific instructions (currently just avx).