### PR TITLE
[cmake] Add dependence from ASan-instrumented libraries onto compiler…

### DIFF
--- a/cmake/Modules/AddCheetah.cmake
+++ b/cmake/Modules/AddCheetah.cmake
@@ -379,6 +379,13 @@ function(add_cheetah_runtime name type)
     if(type STREQUAL "SHARED")
       rt_externalize_debuginfo(${libname})
     endif()
+
+    # Handle the dependence on compiler-rt specially
+    if ("-fsanitize=address" IN_LIST LIB_LINK_FLAGS)
+      if (TARGET asan)
+        add_dependencies(${libname} compiler-rt)
+      endif()
+    endif()
   endforeach()
   if(LIB_PARENT_TARGET)
     add_dependencies(${LIB_PARENT_TARGET} ${libnames})


### PR DESCRIPTION
…-rt, if compiler-rt is being built as an LLVM runtime.

fixes OpenCilk/cheetah#20