### PR TITLE
Allow configuration override of config.mk from cheetah's parent directory

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -22,7 +22,7 @@ RTS_PEDIGREE_LIB?=libopencilk-pedigrees
 # all of those files using the flag --opencilk-resource-dir=/path/to/cheetah.
 RTS_LIBDIR_NAME?=lib/$(shell $(LLVM_CONFIG) --host-target)
 RESOURCE_DIR?=$(CONFIG_DIR)
-RTS_LIBDIR?=$(RESOURCE_DIR)$(RTS_LIBDIR_NAME)
+RTS_LIBDIR?=$(RESOURCE_DIR)/$(RTS_LIBDIR_NAME)
 RTS_OPT?=-fopencilk --opencilk-resource-dir=$(RESOURCE_DIR)
 #RTS_LIB_FLAG=-lcheetah
 

--- a/config.mk
+++ b/config.mk
@@ -1,31 +1,35 @@
-COMPILER_BASE=
+CONFIG_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+-include $(CONFIG_DIR)../cheetah_config.mk
+
+COMPILER_BASE?=
 CC=$(COMPILER_BASE)clang
 CXX=$(COMPILER_BASE)clang++
 LINK_CC=$(CC)
 LLVM_LINK=$(COMPILER_BASE)llvm-link
 LLVM_CONFIG=$(COMPILER_BASE)llvm-config
 #
-ABI_DEF=-DOPENCILK_ABI
+ABI_DEF?=-DOPENCILK_ABI
 # If use cheetah
-RTS_DIR=../runtime
-RTS_LIB=libopencilk
-RTS_C_PERSONALITY_LIB=libopencilk-personality-c
-RTS_CXX_PERSONALITY_LIB=libopencilk-personality-cpp
-RTS_PEDIGREE_LIB=libopencilk-pedigrees
+RTS_DIR?=../runtime
+RTS_LIB?=libopencilk
+RTS_C_PERSONALITY_LIB?=libopencilk-personality-c
+RTS_CXX_PERSONALITY_LIB?=libopencilk-personality-cpp
+RTS_PEDIGREE_LIB?=libopencilk-pedigrees
 
 # All runtime libraries and associated files will be placed in
 # `/oath/to/cheetah/lib/<target-triple>`, so that the compiler can easily find
 # all of those files using the flag --opencilk-resource-dir=/path/to/cheetah.
-RTS_LIBDIR_NAME=lib/$(shell $(LLVM_CONFIG) --host-target)
-RESOURCE_DIR=$(PWD)
-RTS_LIBDIR=$(RESOURCE_DIR)/$(RTS_LIBDIR_NAME)
-RTS_OPT=-fopencilk --opencilk-resource-dir=$(RESOURCE_DIR)
+RTS_LIBDIR_NAME?=lib/$(shell $(LLVM_CONFIG) --host-target)
+RESOURCE_DIR?=$(CONFIG_DIR)
+RTS_LIBDIR?=$(RESOURCE_DIR)$(RTS_LIBDIR_NAME)
+RTS_OPT?=-fopencilk --opencilk-resource-dir=$(RESOURCE_DIR)
 #RTS_LIB_FLAG=-lcheetah
 
 #ARCH = -mavx
-OPT = -O3
-DBG = -g3
+OPT ?= -O3
+DBG ?= -g3
 # A large number of processors, system-dependent
 # TODO: There should be an additional value meaning "all cores"
-MANYPROC = 8
+MANYPROC ?= 8
 

--- a/handcomp_test/Makefile
+++ b/handcomp_test/Makefile
@@ -12,9 +12,8 @@ OPTIONS = $(OPT) $(ARCH) $(DBG) -Wall $(DEFINES) -fno-omit-frame-pointer
 # RTS_DLIBS = -L../runtime -Wl,-rpath -Wl,../runtime -lopencilk
 # RTS_LIBS = ../runtime/$(RTS_LIB).so
 # static linking
-RESOURCE_DIR=$(realpath ..)
 RTS_LIBS = $(RTS_LIBDIR)/$(RTS_LIB).a
-TIMING_COUNT := 1
+TIMING_COUNT ?= 1
 
 .PHONY: all check memcheck clean
 


### PR DESCRIPTION
While config.mk is useful on its own, and serves as a default/template configuration, it is inconventient in that it is tracked by the repo. This change checks cheetah's parent directory for a cheetah_config.mk file, and use the variables from that file if set. It is placed in the parent directory rather than a gitignored file in the same folder such that projects using cheetah as a submodule can store a permanent override in their own repository if desired (e.g. [my own opencilk-dev repository](https://github.com/kyle-singer/opencilk-dev)).