### PR TITLE
Eliminate a lot of worker arguments.

### DIFF
--- a/runtime/cilk2c.c
+++ b/runtime/cilk2c.c
@@ -62,7 +62,7 @@ int __cilkrts_atexit(void (*callback)(void)) {
 // was thrown.
 void __cilkrts_check_exception_raise(__cilkrts_stack_frame *sf) {
     __cilkrts_worker *w = get_worker_from_stack(sf);
-    CILK_ASSERT_POINTER_EQUAL(w, w, __cilkrts_get_tls_worker());
+    CILK_ASSERT_POINTER_EQUAL(w, __cilkrts_get_tls_worker());
 
     struct closure_exception *exn_r = get_exception_reducer(w);
     char *exn = exn_r->exn;
@@ -83,7 +83,7 @@ void __cilkrts_check_exception_raise(__cilkrts_stack_frame *sf) {
 // resumes unwinding with that exception.
 void __cilkrts_check_exception_resume(__cilkrts_stack_frame *sf) {
     __cilkrts_worker *w = get_worker_from_stack(sf);
-    CILK_ASSERT_POINTER_EQUAL(w, w, __cilkrts_get_tls_worker());
+    CILK_ASSERT_POINTER_EQUAL(w, __cilkrts_get_tls_worker());
 
     struct closure_exception *exn_r = get_exception_reducer(w);
     char *exn = exn_r->exn;
@@ -105,10 +105,12 @@ void __cilkrts_check_exception_resume(__cilkrts_stack_frame *sf) {
 // points at the fiber and call-stack frame containing sf before any catch
 // handlers in that frame execute.
 void __cilkrts_cleanup_fiber(__cilkrts_stack_frame *sf, int32_t sel) {
-    __cilkrts_worker *w = get_worker_from_stack(sf);
-    CILK_ASSERT_POINTER_EQUAL(w, w, __cilkrts_get_tls_worker());
+    (void)sel; // currently unused
 
-    CILK_ASSERT(w, __cilkrts_synced(sf));
+    __cilkrts_worker *w = get_worker_from_stack(sf);
+    CILK_ASSERT_POINTER_EQUAL(w, __cilkrts_get_tls_worker());
+
+    CILK_ASSERT(__cilkrts_synced(sf));
 
     struct closure_exception *exn_r = get_exception_reducer_or_null(w);
     struct cilk_fiber *throwing_fiber = NULL;
@@ -153,9 +155,9 @@ void __cilkrts_cleanup_fiber(__cilkrts_stack_frame *sf, int32_t sel) {
 
 void __cilkrts_sync(__cilkrts_stack_frame *sf) {
     __cilkrts_worker *w = get_worker_from_stack(sf);
-    CILK_ASSERT_POINTER_EQUAL(w, w, __cilkrts_get_tls_worker());
+    CILK_ASSERT_POINTER_EQUAL(w, __cilkrts_get_tls_worker());
 
-    CILK_ASSERT(w, CHECK_CILK_FRAME_MAGIC(w->g, sf));
+    CILK_ASSERT(CHECK_CILK_FRAME_MAGIC(w->g, sf));
 
     if (Cilk_sync(w, sf) == SYNC_READY) {
         // The Cilk_sync restores the original rsp stored in sf->ctx

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -58,8 +58,9 @@ void cilk_die_internal(struct global_state *const g, const char *fmt, ...) {
 }
 
 CHEETAH_INTERNAL_NORETURN
-void cilkrts_bug(__cilkrts_worker *w, const char *fmt, ...) {
+void cilkrts_bug(const char *fmt, ...) {
     fflush(NULL);
+    __cilkrts_worker *w = __cilkrts_get_tls_worker();
     if (w) {
         cilk_mutex_lock(&(w->g->print_lock));
         flush_alert_log();
@@ -99,11 +100,14 @@ static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 #if !(ALERT_LVL & (ALERT_CFRAME|ALERT_RETURN))
 CHEETAH_INTERNAL
 #endif
-void cilkrts_alert(const int lvl, __cilkrts_worker *w, const char *fmt, ...) {
-    if (ALERT_LVL == 0)
+void cilkrts_alert(const int lvl, const char *fmt, ...) {
+    if ((ALERT_LVL & lvl) == 0)
         return;
     char prefix[10], body[200];
     size_t size1 = 0, size2 = 0;
+
+    __cilkrts_worker *w = __cilkrts_get_tls_worker();
+
     if (w) {
         size1 = snprintf(prefix, sizeof prefix, "[W%02u]: ", w->self);
         assert(size1 >= 7 && size1 < 10);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -330,28 +330,29 @@ static void free_stack(struct cilk_fiber *f) {
 // Supported public functions
 //===============================================================
 
-struct cilk_fiber *cilk_fiber_allocate(__cilkrts_worker *w, size_t stacksize) {
+struct cilk_fiber *cilk_fiber_allocate(size_t stacksize) {
     struct cilk_fiber *fiber = make_stack(stacksize);
     init_fiber_header(fiber);
-    cilkrts_alert(FIBER, w, "Allocate fiber %p [%p--%p]", (void *)fiber,
+    cilkrts_alert(FIBER, "Allocate fiber %p [%p--%p]", (void *)fiber,
                   (void *)fiber->stack_low,
                   (void *)sysdep_get_stack_start(fiber));
     return fiber;
 }
 
-void cilk_fiber_deallocate(__cilkrts_worker *w, struct cilk_fiber *fiber) {
-    cilkrts_alert(FIBER, w, "Deallocate fiber %p [%p--%p]", (void *)fiber,
+void cilk_fiber_deallocate(struct cilk_fiber *fiber) {
+    cilkrts_alert(FIBER, "Deallocate fiber %p [%p--%p]", (void *)fiber,
                   (void *)fiber->stack_low,
                   (void *)sysdep_get_stack_start(fiber));
     if (DEBUG_ENABLED_STATIC(FIBER))
-        CILK_ASSERT(
-            w, !in_fiber(fiber, fiber->current_stack_frame));
+        CILK_ASSERT(!in_fiber(fiber, fiber->current_stack_frame));
     free_stack(fiber);
 }
 
 void cilk_fiber_deallocate_global(struct global_state *g,
                                   struct cilk_fiber *fiber) {
-    cilkrts_alert(FIBER, NULL, "Deallocate fiber %p [%p--%p]", (void *)fiber,
+    (void)g; // not currently used
+
+    cilkrts_alert(FIBER, "Deallocate fiber %p [%p--%p]", (void *)fiber,
                   (void *)fiber->stack_low,
                   (void *)sysdep_get_stack_start(fiber));
     free_stack(fiber);

--- a/runtime/global.c
+++ b/runtime/global.c
@@ -46,7 +46,7 @@ static void set_alert_debug_level() {
 }
 
 static global_state *global_state_allocate() {
-    cilkrts_alert(BOOT, NULL,
+    cilkrts_alert(BOOT,
                   "(global_state_init) Allocating global state");
     global_state *g = (global_state *)cilk_aligned_alloc(
         __alignof(global_state), sizeof(global_state));
@@ -70,34 +70,34 @@ static global_state *global_state_allocate() {
 
 static void set_stacksize(global_state *g, size_t stacksize) {
     // TODO: Verify that g has not yet been initialized.
-    CILK_ASSERT_G(!g->workers_started);
-    CILK_ASSERT_G(stacksize >= 16384);
-    CILK_ASSERT_G(stacksize <= 100 * 1024 * 1024);
+    CILK_ASSERT(!g->workers_started);
+    CILK_ASSERT(stacksize >= 16384);
+    CILK_ASSERT(stacksize <= 100 * 1024 * 1024);
     g->options.stacksize = stacksize;
 }
 
 static void set_deqdepth(global_state *g, unsigned int deqdepth) {
     // TODO: Verify that g has not yet been initialized.
-    CILK_ASSERT_G(!g->workers_started);
-    CILK_ASSERT_G(deqdepth >= 1);
-    CILK_ASSERT_G(deqdepth <= 99999);
+    CILK_ASSERT(!g->workers_started);
+    CILK_ASSERT(deqdepth >= 1);
+    CILK_ASSERT(deqdepth <= 99999);
     g->options.deqdepth = deqdepth;
 }
 
 static void set_fiber_pool_cap(global_state *g, unsigned int fiber_pool_cap) {
     // TODO: Verify that g has not yet been initialized.
-    CILK_ASSERT_G(!g->workers_started);
-    CILK_ASSERT_G(fiber_pool_cap >= 2);
-    CILK_ASSERT_G(fiber_pool_cap <= 999999);
+    CILK_ASSERT(!g->workers_started);
+    CILK_ASSERT(fiber_pool_cap >= 2);
+    CILK_ASSERT(fiber_pool_cap <= 999999);
     g->options.fiber_pool_cap = fiber_pool_cap;
 }
 
 // not marked as static as it's called by __cilkrts_internal_set_nworkers
 // used by Cilksan to set nworker to 1 
 void set_nworkers(global_state *g, unsigned int nworkers) {
-    CILK_ASSERT_G(!g->workers_started);
-    CILK_ASSERT_G(nworkers <= g->options.nproc);
-    CILK_ASSERT_G(nworkers > 0);
+    CILK_ASSERT(!g->workers_started);
+    CILK_ASSERT(nworkers <= g->options.nproc);
+    CILK_ASSERT(nworkers > 0);
     g->nworkers = nworkers;
 }
 
@@ -140,13 +140,15 @@ static void parse_rts_environment(global_state *g) {
         }
 #endif
     } else {
-        CILK_ASSERT_G(g->options.nproc < 10000);
+        CILK_ASSERT(g->options.nproc < 10000);
     }
 }
 
 global_state *global_state_init(int argc, char *argv[]) {
-    cilkrts_alert(BOOT, NULL,
-                  "(global_state_init) Initializing global state");
+    cilkrts_alert(BOOT, "(global_state_init) Initializing global state");
+
+    (void)argc; // not currently used
+    (void)argv; // not currently used
 
 #ifdef DEBUG
     setlinebuf(stderr);
@@ -159,7 +161,7 @@ global_state *global_state_init(int argc, char *argv[]) {
     parse_rts_environment(g);
 
     unsigned active_size = g->options.nproc;
-    CILK_ASSERT_G(active_size > 0);
+    CILK_ASSERT(active_size > 0);
     g->nworkers = active_size;
     cilkg_nproc = active_size;
 

--- a/runtime/jmpbuf.h
+++ b/runtime/jmpbuf.h
@@ -56,6 +56,6 @@ typedef void *jmpbuf[JMPBUF_SIZE];
         char *x_sp;                                                            \
         ASM_GET_FP(x_bp);                                                      \
         ASM_GET_SP(x_sp);                                                      \
-        cilkrts_alert((lvl), (w), "rbp %p rsp %p", x_bp, x_sp);                \
+        cilkrts_alert((lvl), "rbp %p rsp %p", x_bp, x_sp);                \
     }
 #endif

--- a/runtime/local-hypertable.c
+++ b/runtime/local-hypertable.c
@@ -379,8 +379,7 @@ void *__cilkrts_insert_new_view(hyper_table *table, uintptr_t key, size_t size,
 
 // Merge two hypertables, left and right.  Returns the merged hypertable and
 // deletes the other.
-hyper_table *merge_two_hts(__cilkrts_worker *restrict w,
-                           hyper_table *restrict left,
+hyper_table *merge_two_hts(hyper_table *restrict left,
                            hyper_table *restrict right) {
     // In the trivial case of an empty hyper_table, return the other
     // hyper_table.

--- a/runtime/local-hypertable.h
+++ b/runtime/local-hypertable.h
@@ -46,8 +46,7 @@ CHEETAH_INTERNAL
 bool insert_hyperobject(hyper_table *table, struct bucket b);
 
 CHEETAH_INTERNAL
-hyper_table *merge_two_hts(__cilkrts_worker *restrict w,
-                           hyper_table *restrict left,
+hyper_table *merge_two_hts(hyper_table *restrict left,
                            hyper_table *restrict right);
 
 #ifndef MOCK_HASH

--- a/runtime/pedigree_ext.c
+++ b/runtime/pedigree_ext.c
@@ -38,6 +38,7 @@ void __cilkrts_extend_spawn(__cilkrts_worker *w, void **parent_extension,
 void __cilkrts_extend_return_from_spawn(__cilkrts_worker *w, void **extension) {
     // Free the pedigree frame.
     pop_pedigree_frame(w);
+    (void)extension; // TODO: Remove the parameter?
 }
 
 void __cilkrts_extend_sync(void **extension) {

--- a/runtime/readydeque.h
+++ b/runtime/readydeque.h
@@ -29,10 +29,12 @@ struct ReadyDeque {
  *********************************************************/
 
 static inline void deque_assert_ownership(ReadyDeque *deques,
-                                          __cilkrts_worker *const w,
                                           worker_id self, worker_id pn) {
-    CILK_ASSERT(w, atomic_load_explicit(&deques[pn].mutex_owner,
+    CILK_ASSERT(atomic_load_explicit(&deques[pn].mutex_owner,
                                         memory_order_relaxed) == self);
+    (void)deques;
+    (void)self;
+    (void)pn;
 }
 
 static inline void deque_lock_self(ReadyDeque *deques, worker_id self) {
@@ -84,6 +86,7 @@ static inline void deque_lock(ReadyDeque *deques, worker_id self,
 
 static inline void deque_unlock(ReadyDeque *deques, worker_id self,
                                 worker_id pn) {
+    (void)self; // TODO: Remove unused parameter?
     atomic_store_explicit(&deques[pn].mutex_owner, NO_WORKER,
                           memory_order_release);
 }
@@ -95,30 +98,29 @@ static inline void deque_unlock(ReadyDeque *deques, worker_id self,
  * ANGE: the precondition of these functions is that the worker w -> self
  * must have locked worker pn's deque before entering the function
  */
-static inline Closure *deque_xtract_top(ReadyDeque *deques,
-                                        __cilkrts_worker *const w,
-                                        worker_id self, worker_id pn) {
+static inline Closure *deque_xtract_top(ReadyDeque *deques, worker_id self,
+                                        worker_id pn) {
 
     Closure *cl;
 
     /* ANGE: make sure w has the lock on worker pn's deque */
-    deque_assert_ownership(deques, w, self, pn);
+    deque_assert_ownership(deques, self, pn);
 
     cl = deques[pn].top;
     if (cl) {
-        CILK_ASSERT(w, cl->owner_ready_deque == pn);
+        CILK_ASSERT(cl->owner_ready_deque == pn);
         deques[pn].top = cl->next_ready;
         /* ANGE: if there is only one entry in the deque ... */
         if (cl == deques[pn].bottom) {
-            CILK_ASSERT(w, cl->next_ready == (Closure *)NULL);
+            CILK_ASSERT(cl->next_ready == (Closure *)NULL);
             deques[pn].bottom = (Closure *)NULL;
         } else {
-            CILK_ASSERT(w, cl->next_ready);
+            CILK_ASSERT(cl->next_ready);
             (cl->next_ready)->prev_ready = (Closure *)NULL;
         }
         WHEN_CILK_DEBUG(cl->owner_ready_deque = NO_WORKER);
     } else {
-        CILK_ASSERT(w, deques[pn].bottom == (Closure *)NULL);
+        CILK_ASSERT(deques[pn].bottom == (Closure *)NULL);
     }
 
     return cl;
@@ -128,10 +130,12 @@ static inline Closure *deque_peek_top(ReadyDeque *deques,
                                       __cilkrts_worker *const w, worker_id self,
                                       worker_id pn) {
 
+    (void)w;  // unused if assertions disabled
+
     Closure *cl;
 
     /* ANGE: make sure w has the lock on worker pn's deque */
-    deque_assert_ownership(deques, w, self, pn);
+    deque_assert_ownership(deques, self, pn);
 
     /* ANGE: return the top but does not unlink it from the rest */
     cl = deques[pn].top;
@@ -140,58 +144,56 @@ static inline Closure *deque_peek_top(ReadyDeque *deques,
         // who is in the midst of exiting a Cilkified region.  In that case, cl
         // will be the root closure, and cl->owner_ready_deque is not
         // necessarily pn.  The steal will subsequently fail do_dekker_on.
-        CILK_ASSERT(w, cl->owner_ready_deque == pn ||
+        CILK_ASSERT(cl->owner_ready_deque == pn ||
                            (self != pn && cl == w->g->root_closure));
     } else {
-        CILK_ASSERT(w, deques[pn].bottom == (Closure *)NULL);
+        CILK_ASSERT(deques[pn].bottom == (Closure *)NULL);
     }
 
     return cl;
 }
 
-static inline Closure *deque_xtract_bottom(ReadyDeque *deques,
-                                           __cilkrts_worker *const w,
-                                           worker_id self,
+static inline Closure *deque_xtract_bottom(ReadyDeque *deques, worker_id self,
                                            worker_id pn) {
 
     Closure *cl;
 
     /* ANGE: make sure w has the lock on worker pn's deque */
-    deque_assert_ownership(deques, w, self, pn);
+    deque_assert_ownership(deques, self, pn);
 
     cl = deques[pn].bottom;
     if (cl) {
-        CILK_ASSERT(w, cl->owner_ready_deque == pn);
+        CILK_ASSERT(cl->owner_ready_deque == pn);
         deques[pn].bottom = cl->prev_ready;
         if (cl == deques[pn].top) {
-            CILK_ASSERT(w, cl->prev_ready == (Closure *)NULL);
+            CILK_ASSERT(cl->prev_ready == (Closure *)NULL);
             deques[pn].top = (Closure *)NULL;
         } else {
-            CILK_ASSERT(w, cl->prev_ready);
+            CILK_ASSERT(cl->prev_ready);
             (cl->prev_ready)->next_ready = (Closure *)NULL;
         }
 
         WHEN_CILK_DEBUG(cl->owner_ready_deque = NO_WORKER);
     } else {
-        CILK_ASSERT(w, deques[pn].top == (Closure *)NULL);
+        CILK_ASSERT(deques[pn].top == (Closure *)NULL);
     }
 
     return cl;
 }
 
 static inline Closure *
-deque_peek_bottom(ReadyDeque *deques, __cilkrts_worker *const w, worker_id self, worker_id pn) {
+deque_peek_bottom(ReadyDeque *deques, worker_id self, worker_id pn) {
 
     Closure *cl;
 
     /* ANGE: make sure w has the lock on worker pn's deque */
-    deque_assert_ownership(deques, w, self, pn);
+    deque_assert_ownership(deques, self, pn);
 
     cl = deques[pn].bottom;
     if (cl) {
-        CILK_ASSERT(w, cl->owner_ready_deque == pn);
+        CILK_ASSERT(cl->owner_ready_deque == pn);
     } else {
-        CILK_ASSERT(w, deques[pn].top == (Closure *)NULL);
+        CILK_ASSERT(deques[pn].top == (Closure *)NULL);
     }
 
     return cl;
@@ -201,12 +203,11 @@ deque_peek_bottom(ReadyDeque *deques, __cilkrts_worker *const w, worker_id self,
  * ANGE: this allow w -> self to append Closure cl onto worker pn's ready
  *       deque (i.e. make cl the new bottom).
  */
-static inline void deque_add_bottom(ReadyDeque *deques,
-                                    __cilkrts_worker *const w, Closure *cl,
+static inline void deque_add_bottom(ReadyDeque *deques, Closure *cl,
                                     worker_id self, worker_id pn) {
 
-    deque_assert_ownership(deques, w, self, pn);
-    CILK_ASSERT(w, cl->owner_ready_deque == NO_WORKER);
+    deque_assert_ownership(deques, self, pn);
+    CILK_ASSERT(cl->owner_ready_deque == NO_WORKER);
 
     cl->prev_ready = deques[pn].bottom;
     cl->next_ready = (Closure *)NULL;
@@ -214,7 +215,7 @@ static inline void deque_add_bottom(ReadyDeque *deques,
     WHEN_CILK_DEBUG(cl->owner_ready_deque = pn);
 
     if (deques[pn].top) {
-        CILK_ASSERT(w, cl->prev_ready);
+        CILK_ASSERT(cl->prev_ready);
         (cl->prev_ready)->next_ready = cl;
     } else {
         deques[pn].top = cl;

--- a/runtime/sched_stats.c
+++ b/runtime/sched_stats.c
@@ -85,7 +85,7 @@ void cilk_sched_stats_init(struct sched_stats *s) {
 void cilk_start_timing(__cilkrts_worker *w, enum timing_type t) {
     if (w) {
         struct sched_stats *s = &(w->l->stats);
-        CILK_ASSERT(w, s->begin[t] == 0);
+        CILK_ASSERT(s->begin[t] == 0);
         s->end[t] = 0;
         s->begin[t] = begin_time();
     }
@@ -94,9 +94,9 @@ void cilk_start_timing(__cilkrts_worker *w, enum timing_type t) {
 void cilk_stop_timing(__cilkrts_worker *w, enum timing_type t) {
     if (w) {
         struct sched_stats *s = &(w->l->stats);
-        CILK_ASSERT(w, s->end[t] == 0);
+        CILK_ASSERT(s->end[t] == 0);
         s->end[t] = end_time();
-        CILK_ASSERT(w, s->end[t] >= s->begin[t]);
+        CILK_ASSERT(s->end[t] >= s->begin[t]);
         s->time[t] += (s->end[t] - s->begin[t]);
         s->count[t]++;
         s->begin[t] = 0;
@@ -108,15 +108,15 @@ void cilk_switch_timing(__cilkrts_worker *w, enum timing_type t1,
     if (w) {
         struct sched_stats *s = &(w->l->stats);
         // Stop timer t1
-        CILK_ASSERT(w, s->end[t1] == 0);
+        CILK_ASSERT(s->end[t1] == 0);
         s->end[t1] = end_time();
-        CILK_ASSERT(w, s->end[t1] >= s->begin[t1]);
+        CILK_ASSERT(s->end[t1] >= s->begin[t1]);
         s->time[t1] += (s->end[t1] - s->begin[t1]);
         s->count[t1]++;
         s->begin[t1] = 0;
 
         // Start timer t2 where t1 left off
-        CILK_ASSERT(w, s->begin[t2] == 0);
+        CILK_ASSERT(s->begin[t2] == 0);
         s->end[t2] = 0;
         s->begin[t2] = begin_time();
     }
@@ -125,24 +125,24 @@ void cilk_switch_timing(__cilkrts_worker *w, enum timing_type t1,
 void cilk_drop_timing(__cilkrts_worker *w, enum timing_type t) {
     if (w) {
         struct sched_stats *s = &(w->l->stats);
-        CILK_ASSERT(w, s->begin[t] != 0);
+        CILK_ASSERT(s->begin[t] != 0);
         s->begin[t] = 0;
     }
 }
 
 void cilk_boss_start_timing(struct global_state *g) {
     struct global_sched_stats *s = &(g->stats);
-    CILK_ASSERT_G(s->boss_begin == 0);
+    CILK_ASSERT(s->boss_begin == 0);
     s->boss_begin = begin_time();
     s->boss_end = 0;
 }
 
 void cilk_boss_stop_timing(struct global_state *g) {
     struct global_sched_stats *s = &(g->stats);
-    CILK_ASSERT_G(s->boss_end == 0);
+    CILK_ASSERT(s->boss_end == 0);
     s->boss_end = end_time();
-    CILK_ASSERT_G(s->boss_end >= s->boss_begin);
-    CILK_ASSERT_G(s->boss_end >= s->exit_time);
+    CILK_ASSERT(s->boss_end >= s->boss_begin);
+    CILK_ASSERT(s->boss_end >= s->exit_time);
     uint64_t last = s->exit_time > s->boss_begin ? s->exit_time : s->boss_begin;
     s->boss_waiting += (s->boss_end - last);
     s->boss_wait_count++;
@@ -152,7 +152,7 @@ void cilk_boss_stop_timing(struct global_state *g) {
 
 void cilk_exit_worker_timing(struct global_state *g) {
     struct global_sched_stats *s = &(g->stats);
-    CILK_ASSERT_G(s->exit_time == 0);
+    CILK_ASSERT(s->exit_time == 0);
     s->exit_time = begin_time();
 }
 

--- a/runtime/worker_coord.h
+++ b/runtime/worker_coord.h
@@ -166,7 +166,7 @@ static inline void reset_disengaged_var(global_state *g) {
 
 // Request to reengage `count` thief threads.
 static inline void request_more_thieves(global_state *g, uint32_t count) {
-    CILK_ASSERT_G(count > 0);
+    CILK_ASSERT(count > 0);
 
     // Don't allow this routine increment the futex beyond half the number of
     // workers on the system.  This bounds how many successful steals can


### PR DESCRIPTION
In slow code paths the worker can be read from thread local storage.