### PR TITLE
Passing parent stack frames to spawn-helper functions

### DIFF
--- a/runtime/cilk-internal.h
+++ b/runtime/cilk-internal.h
@@ -14,7 +14,6 @@ extern "C" {
 #include "fiber-header.h"
 #include "frame.h"
 #include "internal-malloc.h"
-#include "jmpbuf.h"
 #include "rts-config.h"
 #include "sched_stats.h"
 #include "types.h"

--- a/runtime/cilk2c.h
+++ b/runtime/cilk2c.h
@@ -35,7 +35,9 @@ CHEETAH_INTERNAL void __cilkrts_enter_frame(__cilkrts_stack_frame *sf);
 
 // Inserted at the entry of a spawn helper, i.e., a function that must have been
 // spawned.  Initializes the stack frame sf allocated for that function.
-CHEETAH_INTERNAL void __cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf);
+CHEETAH_INTERNAL void
+__cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf,
+                             __cilkrts_stack_frame *parent, bool spawner);
 
 // Prepare to perform a spawn.  This function may return once or twice,
 // returning 0 the first time and 1 the second time.  This function is intended
@@ -48,7 +50,8 @@ CHEETAH_INTERNAL int __cilk_prepare_spawn(__cilkrts_stack_frame *sf);
 
 // Called in the spawn helper immediately before the spawned computation.
 // Enables the parent function to be stollen.
-CHEETAH_INTERNAL void __cilkrts_detach(__cilkrts_stack_frame *sf);
+CHEETAH_INTERNAL void __cilkrts_detach(__cilkrts_stack_frame *sf,
+                                       __cilkrts_stack_frame *parent);
 
 // Check if the runtime is storing an exception we need to handle later, and
 // raises that exception if so.
@@ -81,14 +84,18 @@ CHEETAH_INTERNAL void __cilkrts_leave_frame(__cilkrts_stack_frame *sf);
 
 // Inserted on return from a spawn-helper function.  Performs Cilk's return
 // protocol for such functions.
-CHEETAH_INTERNAL void __cilkrts_leave_frame_helper(__cilkrts_stack_frame *sf);
+CHEETAH_INTERNAL void
+__cilkrts_leave_frame_helper(__cilkrts_stack_frame *sf,
+                             __cilkrts_stack_frame *parent, bool spawner);
 
 // Performs all necessary operations on return from a spawning function that is
 // not itself a spawn helper.
 CHEETAH_INTERNAL void __cilk_parent_epilogue(__cilkrts_stack_frame *sf);
 
 // Performs all necessary operations on return from a spawn-helper function.
-CHEETAH_INTERNAL void __cilk_helper_epilogue(__cilkrts_stack_frame *sf);
+CHEETAH_INTERNAL void __cilk_helper_epilogue(__cilkrts_stack_frame *sf,
+                                             __cilkrts_stack_frame *parent,
+                                             bool spawner);
 
 // Performs all necessary runtime updates when execution enters a landingpad in
 // a spawning function.
@@ -101,11 +108,15 @@ CHEETAH_API void __cilkrts_cleanup_fiber(__cilkrts_stack_frame *, int32_t sel);
 
 // Performs Cilk's return protocol on an exceptional return (i.e., a resume)
 // from a spawn-helper function.
-CHEETAH_INTERNAL void __cilkrts_pause_frame(__cilkrts_stack_frame *sf, char *exn);
+CHEETAH_INTERNAL void __cilkrts_pause_frame(__cilkrts_stack_frame *sf,
+                                            __cilkrts_stack_frame *parent,
+                                            char *exn, bool spawner);
 
 // Inserted on an exceptional return (i.e., a resume) from a spawn-helper
 // function.
-CHEETAH_INTERNAL void __cilk_pause_frame(__cilkrts_stack_frame *sf, char *exn);
+CHEETAH_INTERNAL void __cilk_pause_frame(__cilkrts_stack_frame *sf,
+                                         __cilkrts_stack_frame *parent,
+                                         char *exn, bool spawner);
 
 // Compute the grainsize for a cilk_for loop at runtime, based on the number n
 // of loop iterations.

--- a/runtime/cilk2c_inlined.c
+++ b/runtime/cilk2c_inlined.c
@@ -16,9 +16,7 @@
 #include "frame.h"
 #include "global.h"
 #include "init.h"
-#include "jmpbuf.h"
 #include "local-reducer-api.h"
-#include "readydeque.h"
 #include "scheduler.h"
 
 #include "pedigree_ext.c"

--- a/runtime/cilk2c_inlined.c
+++ b/runtime/cilk2c_inlined.c
@@ -127,9 +127,6 @@ __cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf,
     sf->flags = 0;
     sf->magic = frame_magic;
 
-    // struct cilk_fiber *fh = __cilkrts_current_fh;
-    // sf->fh = fh;
-    // sf->call_parent = fh->current_stack_frame;
     struct cilk_fiber *fh = parent->fh;
     sf->fh = fh;
     if (spawner) {
@@ -156,8 +153,6 @@ __cilkrts_detach(__cilkrts_stack_frame *sf, __cilkrts_stack_frame *parent) {
     cilkrts_alert(CFRAME, "__cilkrts_detach %p", (void *)sf);
 
     CILK_ASSERT(CHECK_CILK_FRAME_MAGIC(w->g, sf));
-
-    // struct __cilkrts_stack_frame *parent = sf->call_parent;
 
     if (USE_EXTENSION) {
         __cilkrts_extend_spawn(w, &parent->extension, &w->extension);
@@ -269,7 +264,6 @@ __cilkrts_leave_frame_helper(__cilkrts_stack_frame *sf,
     // Pop this frame off the cactus stack.  This logic used to be in
     // __cilkrts_pop_frame, but has been manually inlined to avoid reloading the
     // worker unnecessarily.
-    // __cilkrts_stack_frame *parent = sf->call_parent;
     if (spawner)
         sf->fh->current_stack_frame = parent;
     if (USE_EXTENSION) {
@@ -335,8 +329,6 @@ __cilkrts_pause_frame(__cilkrts_stack_frame *sf, __cilkrts_stack_frame *parent,
     cilkrts_alert(CFRAME, "__cilkrts_pause_frame %p", (void *)sf);
 
     CILK_ASSERT(CHECK_CILK_FRAME_MAGIC(w->g, sf));
-
-    // __cilkrts_stack_frame *parent = sf->call_parent;
 
     // Pop this frame off the cactus stack.  This logic used to be in
     // __cilkrts_pop_frame, but has been manually inlined to avoid reloading the

--- a/runtime/frame.h
+++ b/runtime/frame.h
@@ -3,8 +3,8 @@
 
 #include "rts-config.h"
 
-#include <stdint.h>
 #include "jmpbuf.h"
+#include <stdint.h>
 
 struct __cilkrts_worker;
 struct __cilkrts_stack_frame;

--- a/runtime/rts-config.h
+++ b/runtime/rts-config.h
@@ -84,7 +84,7 @@ _Static_assert(MAX_NUM_PAGES_PER_STACK >= MIN_NUM_PAGES_PER_STACK, "Invalid Chee
 
 #ifndef LG_STACK_SIZE
 #define LG_STACK_SIZE 20 // 1 MBytes
-#endif 
+#endif
 
 #ifndef DEFAULT_STACK_SIZE
 #define DEFAULT_STACK_SIZE (1U << LG_STACK_SIZE) // 1 MBytes

--- a/runtime/rts-config.h
+++ b/runtime/rts-config.h
@@ -98,8 +98,4 @@ _Static_assert(MAX_NUM_PAGES_PER_STACK >= MIN_NUM_PAGES_PER_STACK, "Invalid Chee
 #define MAX_CALLBACKS 32 // Maximum number of init or exit callbacks
 #endif
 
-#ifndef HYPER_TABLE_HIDDEN
-#define HYPER_TABLE_HIDDEN 1
-#endif
-
 #endif                   // _CONFIG_H


### PR DESCRIPTION
This PR drafts runtime-system changes to pass a pointer to the `__cilkrts_stack_frame` in a parent spawning function, along with other compile-time information, to a spawn helper.  This change allows the spawn helper to access the parent stack frame more efficiently and enables a variety of optimizations to reduce spawn overhead.

- Spawn helpers can avoid looking up the parent stack frame from worker-local storage, which can be costly to access.
- Spawn-helper stack frames need not explicitly store a pointer to the parent stack frame.
- By receiving the compile-time information about whether a spawn helper is itself a spawner, the spawn-helper routines can avoid unnecessary initialization and deinitialization work, such as adding themselves to the cactus stack of `__cilkrts_stack_frame`s.  In this case, the compiler is able to optimize away the spawn-helper's stack frame.

This PR requires the compiler changes in OpenCilk/opencilk-project#252.