### PR TITLE
String cilkrts alert options

### DIFF
--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -3,7 +3,6 @@
 #include "global.h"
 
 #include <assert.h>
-#include <ctype.h>
 #include <search.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -90,7 +90,7 @@ static int parse_alert_level_env(char *alert_env) {
                 new_alert_lvl |= parse_alert_level_str(alert_str);
             }
         } else {
-            for (; alert_str != NULL; alert_str = strtok(NULL, ",")) {
+            for (; alert_str; alert_str = strtok(NULL, ",")) {
                 new_alert_lvl |= parse_alert_level_str(alert_str);
             }
         }

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -96,10 +96,6 @@ static int parse_alert_level_env(char *alert_env) {
         }
     }
 
-    // We may have overwritten NULL with , above;
-    // fix it here
-    alert_env[env_len] = '\0';
-
     return new_alert_lvl;
 }
 

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -132,12 +132,13 @@ static int parse_alert_level_env(const char *const alert_env) {
         }
     }
 
-    set_alert_level(new_alert_lvl);
+    return new_alert_lvl;
 }
 
 void set_alert_level_from_str(const char *const alert_env) {
     if (alert_env) {
         int new_alert_lvl = parse_alert_level_env(alert_env);
+        set_alert_level(new_alert_lvl);
     }
 }
 

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -125,7 +125,7 @@ static int parse_alert_level_csv(const char *const alert_csv) {
 
     // strtok modifies the passed in string, so copy alert_csv and use
     // the copy instead
-    char *alert_csv_cpy = malloc(csv_len + 1);
+    char *alert_csv_cpy = strdup(alert_csv);
     if (!alert_csv_cpy) {
         // Non-critical error, so just print a warning
         fprintf(stderr, "Cilk: unable to copy CILK_ALERT settings (%s)\n",
@@ -133,7 +133,6 @@ static int parse_alert_level_csv(const char *const alert_csv) {
                );
         return alert_level;
     }
-    strcpy(alert_csv_cpy, alert_csv);
 
     char *alert_str = strtok(alert_csv_cpy, ",");
 

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-
 #if ALERT_LVL & (ALERT_CFRAME|ALERT_RETURN)
 unsigned int alert_level = 0;
 #else

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -21,11 +21,20 @@ CHEETAH_INTERNAL unsigned int debug_level = 0;
 static size_t alert_log_size = 0, alert_log_offset = 0;
 static char *alert_log = NULL;
 
+/**
+ * Represents a usable alert level with a human-readable
+ * <code>name<\code> and the corresponding
+ * <code>mask_value<\code> used by the runtime.
+ **/
 typedef struct __alert_level_t {
     const char *name;
     int mask_value;
 } alert_level_t;
 
+/**
+ * A table relating a human-readable alert level name to
+ * the corresponding bitfield value used by the runtime.
+ **/
 static const alert_level_t alert_table[] = {
     {"none", ALERT_NONE},
     {"fiber", ALERT_FIBER},

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -117,14 +117,18 @@ static int parse_alert_level_env(char *alert_env) {
             while (alert_str != NULL) {
                 new_alert_lvl |= parse_alert_level_str(alert_str);
                 char *new_alert_str = strtok(NULL, ",");
-                // add back the delimiter that was removed by strtok;
-                // must be after the above strtok to avoid a segfault
-                // on some implementations of strtok
+                // Do this after reading the next pointer to avoid
+                // (1) branching (if last string) and (2) segfaulting
+                // in strtok due to overwriting the null terminator.
                 alert_str[strlen(alert_str)] = ',';
                 alert_str = new_alert_str;
             }
         }
     }
+
+    // We may have overwritten NULL with , above;
+    // fix it here
+    alert_env[env_len] = '\0';
 
     return new_alert_lvl;
 }

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -54,7 +54,7 @@ extern CHEETAH_INTERNAL unsigned int debug_level;
 // Unused: compiler inlines the stack frame creation
 // #define CILK_STACKFRAME_MAGIC 0xCAFEBABE
 
-CHEETAH_INTERNAL void set_alert_level_from_str(const char *const);
+CHEETAH_INTERNAL void set_alert_level_from_str(char *);
 CHEETAH_INTERNAL void set_alert_level(unsigned int);
 CHEETAH_INTERNAL void set_debug_level(unsigned int);
 CHEETAH_INTERNAL void flush_alert_log(void);

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -30,6 +30,7 @@ struct __cilkrts_worker;
 #define ALERT_BOOT             0x1000
 #define ALERT_START            0x2000
 #define ALERT_CLOSURE          0x4000
+#define ALERT_NOBUF            0x80000000
 
 #if ALERT_LVL & (ALERT_CFRAME|ALERT_RETURN)
 extern unsigned int alert_level;
@@ -53,7 +54,8 @@ extern CHEETAH_INTERNAL unsigned int debug_level;
 // Unused: compiler inlines the stack frame creation
 // #define CILK_STACKFRAME_MAGIC 0xCAFEBABE
 
-CHEETAH_INTERNAL void set_alert_level(const char *const);
+CHEETAH_INTERNAL void set_alert_level_from_str(const char *const);
+CHEETAH_INTERNAL void set_alert_level(unsigned int);
 CHEETAH_INTERNAL void set_debug_level(unsigned int);
 CHEETAH_INTERNAL void flush_alert_log(void);
 

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -54,7 +54,7 @@ extern CHEETAH_INTERNAL unsigned int debug_level;
 // Unused: compiler inlines the stack frame creation
 // #define CILK_STACKFRAME_MAGIC 0xCAFEBABE
 
-CHEETAH_INTERNAL void set_alert_level_from_str(char *);
+CHEETAH_INTERNAL void set_alert_level_from_str(const char *const);
 CHEETAH_INTERNAL void set_alert_level(unsigned int);
 CHEETAH_INTERNAL void set_debug_level(unsigned int);
 CHEETAH_INTERNAL void flush_alert_log(void);

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -53,7 +53,6 @@ extern CHEETAH_INTERNAL unsigned int debug_level;
 // Unused: compiler inlines the stack frame creation
 // #define CILK_STACKFRAME_MAGIC 0xCAFEBABE
 
-//CHEETAH_INTERNAL void set_alert_level(unsigned int);
 CHEETAH_INTERNAL void set_alert_level(const char *const);
 CHEETAH_INTERNAL void set_debug_level(unsigned int);
 CHEETAH_INTERNAL void flush_alert_log(void);

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -30,7 +30,6 @@ struct __cilkrts_worker;
 #define ALERT_BOOT             0x1000
 #define ALERT_START            0x2000
 #define ALERT_CLOSURE          0x4000
-#define ALERT_NOBUF            0x80000000
 
 #if ALERT_LVL & (ALERT_CFRAME|ALERT_RETURN)
 extern unsigned int alert_level;
@@ -54,7 +53,8 @@ extern CHEETAH_INTERNAL unsigned int debug_level;
 // Unused: compiler inlines the stack frame creation
 // #define CILK_STACKFRAME_MAGIC 0xCAFEBABE
 
-CHEETAH_INTERNAL void set_alert_level(unsigned int);
+//CHEETAH_INTERNAL void set_alert_level(unsigned int);
+CHEETAH_INTERNAL void set_alert_level(const char *const);
 CHEETAH_INTERNAL void set_debug_level(unsigned int);
 CHEETAH_INTERNAL void flush_alert_log(void);
 

--- a/runtime/global.c
+++ b/runtime/global.c
@@ -41,7 +41,7 @@ unsigned __cilkrts_nproc = 0;
 
 static void set_alert_debug_level() {
     /* Only the bits also set in ALERT_LVL are used. */
-    set_alert_level(getenv("CILK_ALERT"));
+    set_alert_level_from_str(getenv("CILK_ALERT"));
     /* Only the bits also set in DEBUG_LVL are used. */
     set_debug_level(env_get_int("CILK_DEBUG"));
 }

--- a/runtime/global.c
+++ b/runtime/global.c
@@ -41,7 +41,7 @@ unsigned __cilkrts_nproc = 0;
 
 static void set_alert_debug_level() {
     /* Only the bits also set in ALERT_LVL are used. */
-    set_alert_level(env_get_int("CILK_ALERT"));
+    set_alert_level(getenv("CILK_ALERT"));
     /* Only the bits also set in DEBUG_LVL are used. */
     set_debug_level(env_get_int("CILK_DEBUG"));
 }


### PR DESCRIPTION
Modify CILK_ALERT such that the method for enabling specific alert types is more memorable.
Still allows specifying just a number (as before), but will also accept a comma-separated list of options (excluding numbers).

For example, `CILK_ALERT=fiber,closure` enables ALERT_FIBER and ALERT_CLOSURE printouts from cilkrts_alert.