### PR TITLE
fix segfault when CILK_ALERT=memory (and that alert is enabled)

### DIFF
--- a/runtime/internal-malloc.c
+++ b/runtime/internal-malloc.c
@@ -152,7 +152,7 @@ void dump_memory_state(FILE *out, global_state *g) {
     dump_buckets(out, &g->im_desc);
     for (unsigned int i = 0; i < g->nworkers; i++) {
         __cilkrts_worker *w = g->workers[i];
-        if (!w)
+        if (!w || !w->l)
             continue;
         fprintf(out, "Worker %u:\n", i);
         dump_buckets(out, &w->l->im_desc);


### PR DESCRIPTION
In the constructor function in init.c, __default_cilkrts_startup -> __cilkrts_startup -> Closure_create, the runtime currently segfaults when CILK_ALERT=memory because all worker local states are assumed to be valid if the worker pointer itself is valid when cheetah is dumping memory stats. At this point in the code, however, only worker 0 has a valid local_state pointer.