### PR TITLE
[actions] set LLVM_TARGETS_TO_BUILD=host

### DIFF
--- a/.github/workflows/handcomp-tests.yml
+++ b/.github/workflows/handcomp-tests.yml
@@ -34,6 +34,7 @@ jobs:
       uses: OpenCilk/actions/build-opencilk-project@main
       with:
         projects: clang
+        extra_cmake_args: -DLLVM_TARGETS_TO_BUILD=host
         os_list: '${{ matrix.os }}'
     - name: make
       shell: bash

--- a/.github/workflows/small-cilkapps.yml
+++ b/.github/workflows/small-cilkapps.yml
@@ -34,6 +34,7 @@ jobs:
       uses: OpenCilk/actions/build-opencilk-project@main
       with:
         projects: clang
+        extra_cmake_args: -DLLVM_TARGETS_TO_BUILD=host
         os_list: '${{ matrix.os }}'
     - name: Build cheetah
       id: build-cheetah


### PR DESCRIPTION
Save a bit of github action resources by only compiling llvm to target the host in github actions.