### PR TITLE
Separate definitions for runtime library and bitcode interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,8 @@ if (CHEETAH_USE_COMPILER_RT)
 endif()
 
 # Get warning flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-variable-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-variable-declarations")
 append_string_if(CHEETAH_HAS_WALL_FLAG -Wall CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
 if (CHEETAH_ENABLE_WERROR)

--- a/include/cilk/cilk_api.h
+++ b/include/cilk/cilk_api.h
@@ -7,39 +7,38 @@
 #define __CILKRTS_NOTHROW noexcept
 extern "C" {
 #else
-#define __CILKRTS_NOTHROW
+#define __CILKRTS_NOTHROW __attribute__((nothrow))
 #endif
 
-int __cilkrts_is_initialized(void);
-int __cilkrts_atinit(void (*callback)(void));
-int __cilkrts_atexit(void (*callback)(void));
-unsigned __cilkrts_get_nworkers(void);
+int __cilkrts_is_initialized(void) __CILKRTS_NOTHROW;
+int __cilkrts_atinit(void (*callback)(void)) __CILKRTS_NOTHROW;
+int __cilkrts_atexit(void (*callback)(void)) __CILKRTS_NOTHROW;
+unsigned __cilkrts_get_nworkers(void) __CILKRTS_NOTHROW;
 unsigned __cilkrts_get_worker_number(void) __attribute__((deprecated));
-int __cilkrts_running_on_workers(void);
+int __cilkrts_running_on_workers(void) __CILKRTS_NOTHROW;
 
 #include <inttypes.h>
 typedef struct __cilkrts_pedigree {
     uint64_t rank;
     struct __cilkrts_pedigree *parent;
 } __cilkrts_pedigree;
-__cilkrts_pedigree __cilkrts_get_pedigree(void);
+__cilkrts_pedigree __cilkrts_get_pedigree(void) __CILKRTS_NOTHROW;
 void __cilkrts_bump_worker_rank(void) __CILKRTS_NOTHROW;
-void __cilkrts_dprand_set_seed(uint64_t seed);
-void __cilkrts_init_dprng(void);
-uint64_t __cilkrts_get_dprand(void);
+void __cilkrts_dprand_set_seed(uint64_t seed) __CILKRTS_NOTHROW;
+void __cilkrts_init_dprng(void) __CILKRTS_NOTHROW;
+uint64_t __cilkrts_get_dprand(void) __CILKRTS_NOTHROW;
 
 typedef void (*__cilk_identity_fn)(void *);
 typedef void (*__cilk_reduce_fn)(void *, void *);
 
-/* void *__cilkrts_reducer_lookup(void *key); */
-
-/* void *__cilkrts_reducer_lookup(void *key, size_t size, __cilk_identity_fn id, */
-/*                                __cilk_reduce_fn reduce); */
 void *__cilkrts_reducer_lookup(void *key, size_t size, void *id, void *reduce);
+__attribute__((deprecated))
 void __cilkrts_reducer_register(void *key, size_t size, __cilk_identity_fn id,
                                 __cilk_reduce_fn reduce)
-    __attribute__((deprecated));
-void __cilkrts_reducer_unregister(void *key) __attribute__((deprecated));
+  __CILKRTS_NOTHROW;
+
+__attribute__((deprecated))
+void __cilkrts_reducer_unregister(void *key) __CILKRTS_NOTHROW;
 
 #ifdef __cplusplus
 }

--- a/runtime/cilk-internal.h
+++ b/runtime/cilk-internal.h
@@ -11,6 +11,7 @@ extern "C" {
 #include <cilk/cilk_api.h>
 
 #include "debug.h"
+#include "cilk2c_inlined.h"
 #include "fiber-header.h"
 #include "frame.h"
 #include "internal-malloc.h"
@@ -108,6 +109,24 @@ struct closure_exception {
        currently running. */
     struct cilk_fiber *throwing_fiber;
 };
+
+// Reducer structure for handling exceptions thrown in parallel.
+extern struct closure_exception exception_reducer;
+// Init method for exception reducer.
+CHEETAH_INTERNAL void init_exception_reducer(void *v);
+// Reduce method for exception reducer.
+CHEETAH_INTERNAL void reduce_exception_reducer(void *l, void *r);
+// Retrieve the exception stored in the local view of the exception reducer.
+CHEETAH_INTERNAL struct closure_exception *
+get_exception_reducer(__cilkrts_worker *w);
+// Retrieve the exception stored in the local view of the exception reducer, or
+// NULL if there is no local view..
+CHEETAH_INTERNAL struct closure_exception *
+get_exception_reducer_or_null(__cilkrts_worker *w);
+// Free resources used for a local view of the exception reducer.  This method
+// does not deallocate the exception
+CHEETAH_INTERNAL void clear_exception_reducer(__cilkrts_worker *w,
+                                              struct closure_exception *exn_r);
 
 #ifdef __cplusplus
 }

--- a/runtime/cilk2c.h
+++ b/runtime/cilk2c.h
@@ -4,54 +4,13 @@
 #include "cilk-internal.h"
 #include <stdlib.h>
 
-// Reducer structure for handling exceptions thrown in parallel.
-extern struct closure_exception exception_reducer;
-// Init method for exception reducer.
-CHEETAH_INTERNAL void init_exception_reducer(void *v);
-// Reduce method for exception reducer.
-CHEETAH_INTERNAL void reduce_exception_reducer(void *l, void *r);
-// Retrieve the exception stored in the local view of the exception reducer.
-CHEETAH_INTERNAL struct closure_exception *
-get_exception_reducer(__cilkrts_worker *w);
-// Retrieve the exception stored in the local view of the exception reducer, or
-// NULL if there is no local view..
-CHEETAH_INTERNAL struct closure_exception *
-get_exception_reducer_or_null(__cilkrts_worker *w);
-// Free resources used for a local view of the exception reducer.  This method
-// does not deallocate the exception
-CHEETAH_INTERNAL void clear_exception_reducer(__cilkrts_worker *w,
-                                              struct closure_exception *exn_r);
-
 // Returns 1 if the current exection is running on Cilk workers, 0 otherwise.
 CHEETAH_API int __cilkrts_running_on_workers(void);
 
 // ABI functions inlined by the compiler (provided as a bitcode file after
-// compiling runtime) are defined in cilk2c_inline.c.
+// compiling runtime) are declared in cilk2c_inline.h and defined in
+// cilk2c_inline.c.
 // ABI functions not inlined by the compiler are defined in cilk2c.c.
-
-// Inserted at the entry of a spawning function that is not itself a spawn
-// helper.  Initializes the stack frame sf allocated for that function.
-CHEETAH_INTERNAL void __cilkrts_enter_frame(__cilkrts_stack_frame *sf);
-
-// Inserted at the entry of a spawn helper, i.e., a function that must have been
-// spawned.  Initializes the stack frame sf allocated for that function.
-CHEETAH_INTERNAL void
-__cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf,
-                             __cilkrts_stack_frame *parent, bool spawner);
-
-// Prepare to perform a spawn.  This function may return once or twice,
-// returning 0 the first time and 1 the second time.  This function is intended
-// to be used follows:
-//
-//   if (0 == __cilk_spawn_prepare(sf)) {
-//     spawn_helper(args);
-//   }
-CHEETAH_INTERNAL int __cilk_prepare_spawn(__cilkrts_stack_frame *sf);
-
-// Called in the spawn helper immediately before the spawned computation.
-// Enables the parent function to be stollen.
-CHEETAH_INTERNAL void __cilkrts_detach(__cilkrts_stack_frame *sf,
-                                       __cilkrts_stack_frame *parent);
 
 // Check if the runtime is storing an exception we need to handle later, and
 // raises that exception if so.
@@ -61,71 +20,18 @@ CHEETAH_API void __cilkrts_check_exception_raise(__cilkrts_stack_frame *sf);
 // resumes unwinding with that exception if so.
 CHEETAH_API void __cilkrts_check_exception_resume(__cilkrts_stack_frame *sf);
 
-// Performs runtime operations to handle a cilk_sync.
-__attribute__((noreturn, nothrow))
-CHEETAH_API void __cilkrts_sync(__cilkrts_stack_frame *sf);
-
 // Implements a cilk_sync when the cilk_sync might produce an exception that
 // needs to be handled.
-CHEETAH_INTERNAL void __cilk_sync(__cilkrts_stack_frame *sf);
-
-// Implements a cilk_sync when the cilk_sync is guaranteed not to produce an
-// exception that needs to be handled.
-CHEETAH_INTERNAL void __cilk_sync_nothrow(__cilkrts_stack_frame *sf);
-
-// Deprecated?  Removes the current stack frame from the bottom of the stack.
-// (This logic has been manually inlined into __cilkrts_leave_frame,
-// __cilkrts_leave_frame_helper, and __cilkrts_pause_frame.)
-CHEETAH_INTERNAL void __cilkrts_pop_frame(__cilkrts_stack_frame *sf);
-
-// Inserted on return from a spawning function that is not itself a spawn
-// helper.  Performs Cilk's return protocol for such functions.
-CHEETAH_INTERNAL void __cilkrts_leave_frame(__cilkrts_stack_frame *sf);
-
-// Inserted on return from a spawn-helper function.  Performs Cilk's return
-// protocol for such functions.
-CHEETAH_INTERNAL void
-__cilkrts_leave_frame_helper(__cilkrts_stack_frame *sf,
-                             __cilkrts_stack_frame *parent, bool spawner);
-
-// Performs all necessary operations on return from a spawning function that is
-// not itself a spawn helper.
-CHEETAH_INTERNAL void __cilk_parent_epilogue(__cilkrts_stack_frame *sf);
-
-// Performs all necessary operations on return from a spawn-helper function.
-CHEETAH_INTERNAL void __cilk_helper_epilogue(__cilkrts_stack_frame *sf,
-                                             __cilkrts_stack_frame *parent,
-                                             bool spawner);
-
-// Performs all necessary runtime updates when execution enters a landingpad in
-// a spawning function.
-CHEETAH_INTERNAL
-void __cilkrts_enter_landingpad(__cilkrts_stack_frame *sf, int32_t sel);
+CHEETAH_API void __cilkrts_sync(__cilkrts_stack_frame *sf);
 
 // Called from __cilkrts_enter_landingpad to optionally fix the current stack
 // pointer and cleanup a fiber that was previously saved for exception handling.
 CHEETAH_API void __cilkrts_cleanup_fiber(__cilkrts_stack_frame *, int32_t sel);
 
-// Performs Cilk's return protocol on an exceptional return (i.e., a resume)
-// from a spawn-helper function.
-CHEETAH_INTERNAL void __cilkrts_pause_frame(__cilkrts_stack_frame *sf,
-                                            __cilkrts_stack_frame *parent,
-                                            char *exn, bool spawner);
-
-// Inserted on an exceptional return (i.e., a resume) from a spawn-helper
-// function.
-CHEETAH_INTERNAL void __cilk_pause_frame(__cilkrts_stack_frame *sf,
-                                         __cilkrts_stack_frame *parent,
-                                         char *exn, bool spawner);
-
-// Compute the grainsize for a cilk_for loop at runtime, based on the number n
-// of loop iterations.
-CHEETAH_INTERNAL uint8_t __cilkrts_cilk_for_grainsize_8(uint8_t n);
-CHEETAH_INTERNAL uint16_t __cilkrts_cilk_for_grainsize_16(uint16_t n);
-CHEETAH_INTERNAL uint32_t __cilkrts_cilk_for_grainsize_32(uint32_t n);
-CHEETAH_INTERNAL uint64_t __cilkrts_cilk_for_grainsize_64(uint64_t n);
-
 // Not marked as CHEETAH_API as it may be deprecated soon
 unsigned __cilkrts_get_nworkers(void);
+
+CHEETAH_API void __cilkrts_set_return(__cilkrts_worker *const ws);
+CHEETAH_API void __cilkrts_exception_handler(__cilkrts_worker *w, char *exn);
 
 #endif

--- a/runtime/cilk2c_inlined.c
+++ b/runtime/cilk2c_inlined.c
@@ -2,6 +2,8 @@
 // This file contains the compiler-runtime ABI.  This file is compiled to LLVM
 // bitcode, which the compiler then includes and inlines when it compiles a Cilk
 // program.
+// This file is also linked into the runtime library for use by
+// the exception personality function.
 // =============================================================================
 
 #include <stdatomic.h>
@@ -9,6 +11,7 @@
 #include <unwind.h>
 
 #include "cilk-internal.h"
+#include "cilk2c_inlined.h"
 #include "cilk2c.h"
 #include "debug.h"
 #include "fiber.h"
@@ -21,6 +24,10 @@
 
 #include "pedigree_ext.c"
 #include "worker.h"
+
+// Suppress -Wmissing-variable-declarations for this variable.
+_Alignas(__cilkrts_stack_frame)
+extern size_t __cilkrts_stack_frame_align;
 
 // This variable encodes the alignment of a __cilkrts_stack_frame, both in its
 // value and in its own alignment.  Because LLVM IR does not associate
@@ -97,7 +104,7 @@ uncilkify(global_state *g, __cilkrts_stack_frame *sf) {
 
 // Enter a new Cilk function, i.e., a function that contains a cilk_spawn.  This
 // function must be inlined for correctness.
-__attribute__((always_inline)) void
+__attribute__((always_inline,nothrow)) void
 __cilkrts_enter_frame(__cilkrts_stack_frame *sf) {
     sf->flags = 0;
     if (__cilkrts_need_to_cilkify) {
@@ -119,7 +126,7 @@ __cilkrts_enter_frame(__cilkrts_stack_frame *sf) {
 // This function initializes worker and stack_frame structures.  Because this
 // routine will always be executed by a Cilk worker, it is optimized compared to
 // its counterpart, __cilkrts_enter_frame.
-__attribute__((always_inline)) void
+__attribute__((always_inline,nothrow)) void
 __cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf,
                              __cilkrts_stack_frame *parent, bool spawner) {
     cilkrts_alert(CFRAME, "__cilkrts_enter_frame_helper %p", (void *)sf);
@@ -135,7 +142,7 @@ __cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf,
     }
 }
 
-__attribute__((always_inline)) int
+__attribute__((always_inline,nothrow)) int
 __cilk_prepare_spawn(__cilkrts_stack_frame *sf) {
     sysdep_save_fp_ctrl_state(sf);
     int res = __builtin_setjmp(sf->ctx);
@@ -147,7 +154,7 @@ __cilk_prepare_spawn(__cilkrts_stack_frame *sf) {
 
 // Detach the given Cilk stack frame, allowing other Cilk workers to steal the
 // parent frame.
-__attribute__((always_inline)) void
+__attribute__((always_inline,nothrow)) void
 __cilkrts_detach(__cilkrts_stack_frame *sf, __cilkrts_stack_frame *parent) {
     __cilkrts_worker *w = get_worker_from_stack(sf);
     cilkrts_alert(CFRAME, "__cilkrts_detach %p", (void *)sf);
@@ -238,16 +245,17 @@ __cilkrts_leave_frame(__cilkrts_stack_frame *sf) {
 
     CILK_ASSERT(!(flags & CILK_FRAME_DETACHED));
 
-    // A detached frame would never need to call Cilk_set_return, which performs
+    // A detached frame would never need to call set_return, which performs
     // the return protocol of a full frame back to its parent when the full
     // frame is called (not spawned).  A spawned full frame returning is done
-    // via a different protocol, which is triggered in Cilk_exception_handler.
+    // via a different protocol, which is triggered in
+    // __cilkrts_exception_handler.
     if (flags & CILK_FRAME_STOLEN) { // if this frame has a full frame
         cilkrts_alert(RETURN,
                       "__cilkrts_leave_frame parent is call_parent!");
         // leaving a full frame; need to get the full frame of its call
         // parent back onto the deque
-        Cilk_set_return(w);
+        __cilkrts_set_return(w);
         CILK_ASSERT(CHECK_CILK_FRAME_MAGIC(w->g, sf));
     }
 }
@@ -287,7 +295,7 @@ __cilkrts_leave_frame_helper(__cilkrts_stack_frame *sf,
        DETACHED.  Does it modify flags too? */
     sf->flags &= ~CILK_FRAME_DETACHED;
     if (__builtin_expect(exc > tail, false)) {
-        Cilk_exception_handler(w, NULL);
+        __cilkrts_exception_handler(w, NULL);
         // If Cilk_exception_handler returns this thread won the race and can
         // return to the parent function.
     }
@@ -357,8 +365,8 @@ __cilkrts_pause_frame(__cilkrts_stack_frame *sf, __cilkrts_stack_frame *parent,
            with the clear of DETACHED.  Does it modify flags too? */
         sf->flags &= ~CILK_FRAME_DETACHED;
         if (__builtin_expect(exc > tail, false)) {
-            Cilk_exception_handler(w, exn);
-            // If Cilk_exception_handler returns this thread won
+            __cilkrts_exception_handler(w, exn);
+            // If __cilkrts_exception_handler returns this thread won
             // the race and can return to the parent function.
         }
     }

--- a/runtime/cilk2c_inlined.h
+++ b/runtime/cilk2c_inlined.h
@@ -1,0 +1,97 @@
+// Runtime functions that are known to the compiler.
+// All of these use C linkage.
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "cilk/cilk_api.h"
+
+struct __cilkrts_stack_frame;
+struct __cilkrts_worker;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Inserted at the entry of a spawning function that is not itself a spawn
+// helper.  Initializes the stack frame sf allocated for that function.
+void __cilkrts_enter_frame(struct __cilkrts_stack_frame *sf) __CILKRTS_NOTHROW;
+// Inserted at the entry of a spawn helper, i.e., a function that must have been
+// spawned.  Initializes the stack frame sf allocated for that function.
+void __cilkrts_enter_frame_helper(struct __cilkrts_stack_frame *sf,
+                                  struct __cilkrts_stack_frame *parent,
+                                  bool spawner) __CILKRTS_NOTHROW;
+
+// Prepare to perform a spawn.  This function may return once or twice,
+// returning 0 the first time and 1 the second time.  This function is intended
+// to be used follows:
+//
+//   if (0 == __cilk_spawn_prepare(sf)) {
+//     spawn_helper(args);
+//   }
+int __cilk_prepare_spawn(struct __cilkrts_stack_frame *sf) __CILKRTS_NOTHROW;
+
+// Called in the spawn helper immediately before the spawned computation.
+// Enables the parent function to be stollen.
+void __cilkrts_detach(struct __cilkrts_stack_frame *sf,
+                      struct __cilkrts_stack_frame *parent) __CILKRTS_NOTHROW;
+
+// Inserted on return from a spawning function that is not itself a spawn
+// helper.  Performs Cilk's return protocol for such functions.
+void __cilkrts_leave_frame(struct __cilkrts_stack_frame *sf);
+// Inserted on return from a spawn-helper function.  Performs Cilk's return
+// protocol for such functions.
+void __cilkrts_leave_frame_helper(struct __cilkrts_stack_frame *sf,
+                                  struct __cilkrts_stack_frame *parent,
+                                  bool spawner);
+
+// Performs all necessary operations on return from a spawning function that is
+// not itself a spawn helper.
+void __cilk_parent_epilogue(struct __cilkrts_stack_frame *sf);
+// Performs all necessary operations on return from a spawn-helper function.
+__attribute__((always_inline))
+void __cilk_helper_epilogue(struct __cilkrts_stack_frame *sf,
+                            struct __cilkrts_stack_frame *parent,
+                            bool spawner);
+void __cilk_helper_epilogue_exn(struct __cilkrts_stack_frame *sf,
+                                struct __cilkrts_stack_frame *parent,
+                                char *exn, bool spawner);
+
+void __cilkrts_enter_landingpad(struct __cilkrts_stack_frame *sf, int32_t sel);
+// Performs Cilk's return protocol on an exceptional return (i.e., a resume)
+// from a spawn-helper function.
+void __cilkrts_pause_frame(struct __cilkrts_stack_frame *sf,
+                           struct __cilkrts_stack_frame *parent,
+                           char *exn, bool spawner);
+
+// Compute the grainsize for a cilk_for loop at runtime, based on the number n
+// of loop iterations.
+uint8_t __cilkrts_cilk_for_grainsize_8(uint8_t n) __CILKRTS_NOTHROW;
+uint16_t __cilkrts_cilk_for_grainsize_16(uint16_t n) __CILKRTS_NOTHROW;
+uint32_t __cilkrts_cilk_for_grainsize_32(uint32_t n) __CILKRTS_NOTHROW;
+uint64_t __cilkrts_cilk_for_grainsize_64(uint64_t n) __CILKRTS_NOTHROW;
+
+// Performs runtime operations to handle a cilk_sync.
+void __cilk_sync(struct __cilkrts_stack_frame *sf) __CILKRTS_NOTHROW;
+
+// Implements a cilk_sync when the cilk_sync is guaranteed not to produce an
+// exception that needs to be handled.
+void __cilk_sync_nothrow(struct __cilkrts_stack_frame *sf);
+
+void *__cilkrts_reducer_lookup(void *key, size_t size,
+                               void *id, void *reduce);
+
+void __cilkrts_reducer_register_32(void *key, uint32_t size,
+                                   void (*id)(void *),
+                                   void (*reduce)(void *, void *))
+  __CILKRTS_NOTHROW;
+
+void __cilkrts_reducer_register_64(void *key, uint64_t size,
+                                   void (*id)(void *),
+                                   void (*reduce)(void *, void *))
+  __CILKRTS_NOTHROW;
+
+void __cilkrts_reducer_unregister(void *key) __CILKRTS_NOTHROW;
+
+#ifdef __cplusplus
+}
+#endif

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -92,11 +92,11 @@ static SanitizerFinishSwitchFiberFuncPtr sanitizer_finish_switch_fiber_fn = NULL
 static AsanPoisonMemoryRegionFuncPtr asan_poison_memory_region_fn = NULL;
 static AsanUnpoisonMemoryRegionFuncPtr asan_unpoison_memory_region_fn = NULL;
 
-__thread void *fake_stack_save = NULL;
-const __thread void *old_thread_stack = NULL;
-__thread size_t old_thread_stacksize = 0;
-__thread struct cilk_fiber *current_fiber = NULL;
-__thread bool on_fiber = false;
+static __thread void *fake_stack_save = NULL;
+static const __thread void *old_thread_stack = NULL;
+static __thread size_t old_thread_stacksize = 0;
+static __thread struct cilk_fiber *current_fiber = NULL;
+static __thread bool on_fiber = false;
 
 static SanitizerStartSwitchFiberFuncPtr getStartSwitchFiberFunc() {
     SanitizerStartSwitchFiberFuncPtr fn = NULL;

--- a/runtime/global.c
+++ b/runtime/global.c
@@ -33,8 +33,6 @@ __cilkrts_worker default_worker = {.self = 0,
                                    .exc = NULL,
                                    .head = NULL,
                                    .ltq_limit = NULL};
-CHEETAH_INTERNAL
-local_state default_worker_local_state;
 
 // A global used to calculate grain size.
 unsigned __cilkrts_nproc = 0;

--- a/runtime/init.c
+++ b/runtime/init.c
@@ -35,7 +35,7 @@
 typedef cpuset_t cpu_set_t;
 #endif
 
-extern local_state default_worker_local_state;
+static local_state default_worker_local_state;
 
 static local_state *worker_local_init(local_state *l, global_state *g) {
     l->shadow_stack = (__cilkrts_stack_frame **)calloc(

--- a/runtime/pedigree_lib.c
+++ b/runtime/pedigree_lib.c
@@ -7,12 +7,14 @@
 // Global variables local to the library.
 
 uint64_t __pedigree_dprng_seed = 0x8c679c168e6bf733ul;
-uint64_t __pedigree_dprng_m_X = 0;
+static uint64_t __pedigree_dprng_m_X = 0;
 CHEETAH_INTERNAL
-__pedigree_frame root_frame = {.pedigree = {.rank = 0, .parent = NULL},
-                               .rank = 0,
-                               .dprng_depth = 0,
-                               .dprng_dotproduct = 0};
+static __pedigree_frame root_frame = {
+  .pedigree = {.rank = 0, .parent = NULL},
+  .rank = 0,
+  .dprng_depth = 0,
+  .dprng_dotproduct = 0
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Initialization and deinitialization

--- a/runtime/scheduler.c
+++ b/runtime/scheduler.c
@@ -239,11 +239,11 @@ static Closure *setup_call_parent_resumption(ReadyDeque *deques,
     return t;
 }
 
-void Cilk_set_return(__cilkrts_worker *const w) {
+void __cilkrts_set_return(__cilkrts_worker *const w) {
 
     Closure *t;
 
-    cilkrts_alert(RETURN, "(Cilk_set_return)");
+    cilkrts_alert(RETURN, "(set_return)");
     ReadyDeque *deques = w->g->deques;
     worker_id self = w->self;
 
@@ -539,7 +539,7 @@ static Closure *return_value(__cilkrts_worker *const w, worker_id self,
  *   2. Someone invokes signal_immediate_exception with the closure currently
  *   running on the worker's deque.  This is only possible with abort.
  */
-void Cilk_exception_handler(__cilkrts_worker *w, char *exn) {
+void __cilkrts_exception_handler(__cilkrts_worker *w, char *exn) {
 
     Closure *t;
     worker_id self = w->self;
@@ -551,7 +551,7 @@ void Cilk_exception_handler(__cilkrts_worker *w, char *exn) {
     CILK_ASSERT(t);
     Closure_lock(self, t);
 
-    cilkrts_alert(EXCEPT, "(Cilk_exception_handler) closure %p!", (void *)t);
+    cilkrts_alert(EXCEPT, "(exception_handler) closure %p!", (void *)t);
 
     /* Reset the E pointer. */
     reset_exception_pointer(w, self, t);
@@ -566,7 +566,7 @@ void Cilk_exception_handler(__cilkrts_worker *w, char *exn) {
     __cilkrts_stack_frame **tail =
         atomic_load_explicit(&w->tail, memory_order_relaxed);
     if (head > tail) {
-        cilkrts_alert(EXCEPT, "(Cilk_exception_handler) this is a steal!");
+        cilkrts_alert(EXCEPT, "(exception_handler) this is a steal!");
         if (NULL != exn) {
             // The spawned child is throwing an exception.  Save that exception
             // object for later processing.
@@ -1353,7 +1353,8 @@ static void do_what_it_says(ReadyDeque *deques, __cilkrts_worker *w,
                     l->returning = false;
                     // Attempt to get a closure from the bottom of our deque.
                     // We should already have the lock on the deque at this
-                    // point, as we jumped here from Cilk_exception_handler.
+                    // point, as we jumped here from
+                    // __cilkrts_exception_handler.
                     t = deque_xtract_bottom(deques, self, self);
                     deque_unlock_self(deques, self);
                 }

--- a/runtime/scheduler.h
+++ b/runtime/scheduler.h
@@ -17,9 +17,6 @@ CHEETAH_INTERNAL void __cilkrts_set_tls_worker(__cilkrts_worker *w);
 CHEETAH_INTERNAL int Cilk_sync(__cilkrts_worker *const ws,
                                __cilkrts_stack_frame *frame);
 
-void Cilk_set_return(__cilkrts_worker *const ws);
-void Cilk_exception_handler(__cilkrts_worker *w, char *exn);
-
 CHEETAH_INTERNAL_NORETURN void longjmp_to_runtime(__cilkrts_worker *w);
 CHEETAH_INTERNAL void worker_scheduler(__cilkrts_worker *w, history_t *const history);
 CHEETAH_INTERNAL void *scheduler_thread_proc(void *arg);


### PR DESCRIPTION
The runtime interface called by the user binary is cilk2c. The bitcode interface into the user binary is cilk2_inlined.