### PR TITLE
Move CHEETAH_SAVE_MXCSR to rts-config.h

### DIFF
--- a/runtime/cilk-internal.h
+++ b/runtime/cilk-internal.h
@@ -20,12 +20,6 @@ extern "C" {
 #include "types.h"
 #include "worker.h"
 
-#if defined __i386__ || defined __x86_64__
-#ifdef __SSE__
-#define CHEETAH_SAVE_MXCSR
-#endif
-#endif
-
 struct global_state;
 typedef struct global_state global_state;
 typedef struct local_state local_state;

--- a/runtime/rts-config.h
+++ b/runtime/rts-config.h
@@ -98,4 +98,10 @@ _Static_assert(MAX_NUM_PAGES_PER_STACK >= MIN_NUM_PAGES_PER_STACK, "Invalid Chee
 #define MAX_CALLBACKS 32 // Maximum number of init or exit callbacks
 #endif
 
+#if defined __i386__ || defined __x86_64__
+#ifdef __SSE__
+#define CHEETAH_SAVE_MXCSR
+#endif
+#endif
+
 #endif                   // _CONFIG_H


### PR DESCRIPTION
When some but not all files included cilk-internal.h different parts of the program disagreed on whether to save and restore MXCSR.  This could lead to runtime crashes or subtle floating point oddities.