### PR TITLE
Use more idiomatic cilk_reducer keyword instead of _Hyperobject, and …

### DIFF
--- a/include/cilk/holder.h
+++ b/include/cilk/holder.h
@@ -16,7 +16,7 @@ template <typename A> static void reduce(void *left, void *right) {
 }
 
 template <typename A>
-using holder = A _Hyperobject(init<A>, reduce<A>);
+using holder = A cilk_reducer(init<A>, reduce<A>);
 
 } // namespace cilk
 

--- a/include/cilk/opadd_reducer.h
+++ b/include/cilk/opadd_reducer.h
@@ -13,7 +13,7 @@ template <typename T> static void plus(void *l, void *r) {
     *static_cast<T *>(l) += *static_cast<T *>(r);
 }
 
-template <typename T> using opadd_reducer = T _Hyperobject(zero<T>, plus<T>);
+template <typename T> using opadd_reducer = T cilk_reducer(zero<T>, plus<T>);
 
 } // namespace cilk
 

--- a/include/cilk/ostream_reducer.h
+++ b/include/cilk/ostream_reducer.h
@@ -62,10 +62,10 @@ public:
 
 };
 
-template<typename Char, typename Traits = std::char_traits<Char>>
-  using ostream_reducer = ostream_view<Char, Traits>
-    _Hyperobject(&ostream_view<Char, std::char_traits<Char>>::identity,
-                 &ostream_view<Char, std::char_traits<Char>>::reduce);
+template <typename Char, typename Traits = std::char_traits<Char>>
+using ostream_reducer = ostream_view<Char, Traits>
+    cilk_reducer(&ostream_view<Char, Traits>::identity,
+                 &ostream_view<Char, Traits>::reduce);
 
 } // namespace cilk
 


### PR DESCRIPTION
…correct some template parameters.