### PR TITLE
[cilk2c_inlined] Extend __cilkrts_cilk_for_grainsize functions to tak…

### DIFF
--- a/runtime/cilk2c_inlined.cpp
+++ b/runtime/cilk2c_inlined.cpp
@@ -419,11 +419,11 @@ __internal_preserve_stack_frame_type_helper(void) {
 ///
 ///     grainsize = min(2048, ceil(n / (8 * nworkers)))
 #define __cilkrts_grainsize_fn_impl(NAME, INT_T)                               \
-    __attribute__((always_inline)) INT_T NAME(INT_T n) noexcept {              \
+    __attribute__((always_inline)) INT_T NAME(INT_T n, INT_T bound) noexcept { \
         INT_T small_loop_grainsize = n / (8 * __cilkrts_nproc);                \
         if (small_loop_grainsize <= 1)                                         \
             return 1;                                                          \
-        INT_T large_loop_grainsize = 2048;                                     \
+        INT_T large_loop_grainsize = bound ? bound : 2048;                     \
         return large_loop_grainsize < small_loop_grainsize                     \
                    ? large_loop_grainsize                                      \
                    : small_loop_grainsize;                                     \
@@ -432,11 +432,12 @@ __internal_preserve_stack_frame_type_helper(void) {
     __cilkrts_grainsize_fn_impl(__cilkrts_cilk_for_grainsize_##SZ, uint##SZ##_t)
 
 __attribute__((always_inline)) uint8_t
-__cilkrts_cilk_for_grainsize_8(uint8_t n) noexcept {
+__cilkrts_cilk_for_grainsize_8(uint8_t n, uint8_t bound) noexcept {
     uint8_t small_loop_grainsize = n / (8 * __cilkrts_nproc);
     if (small_loop_grainsize <= 1)
         return 1;
-    return small_loop_grainsize;
+    return (bound && bound < small_loop_grainsize) ? bound
+                                                   : small_loop_grainsize;
 }
 
 __cilkrts_grainsize_fn(16) __cilkrts_grainsize_fn(32) __cilkrts_grainsize_fn(64)

--- a/runtime/cilk2c_inlined.h
+++ b/runtime/cilk2c_inlined.h
@@ -68,10 +68,14 @@ void __cilkrts_pause_frame(struct __cilkrts_stack_frame *sf,
 
 // Compute the grainsize for a cilk_for loop at runtime, based on the number n
 // of loop iterations.
-uint8_t __cilkrts_cilk_for_grainsize_8(uint8_t n) __CILKRTS_NOTHROW;
-uint16_t __cilkrts_cilk_for_grainsize_16(uint16_t n) __CILKRTS_NOTHROW;
-uint32_t __cilkrts_cilk_for_grainsize_32(uint32_t n) __CILKRTS_NOTHROW;
-uint64_t __cilkrts_cilk_for_grainsize_64(uint64_t n) __CILKRTS_NOTHROW;
+uint8_t __cilkrts_cilk_for_grainsize_8(uint8_t n,
+                                       uint8_t bound) __CILKRTS_NOTHROW;
+uint16_t __cilkrts_cilk_for_grainsize_16(uint16_t n,
+                                         uint16_t bound) __CILKRTS_NOTHROW;
+uint32_t __cilkrts_cilk_for_grainsize_32(uint32_t n,
+                                         uint32_t bound) __CILKRTS_NOTHROW;
+uint64_t __cilkrts_cilk_for_grainsize_64(uint64_t n,
+                                         uint64_t bound) __CILKRTS_NOTHROW;
 
 // Performs runtime operations to handle a cilk_sync.
 void __cilk_sync(struct __cilkrts_stack_frame *sf);


### PR DESCRIPTION
…e a second argument that specifies an upper bound on the loop's grainsize.  If this second argument is 0, then these functions fall back to using their default upper bound on the loop's grainsize, e.g., 2048.

This PR implements the OpenCilk runtime changes that match the OpenCilk compiler changes in OpenCilk/opencilk-project#392.