### PR TITLE
Use more idiomatic C++ syntax for types, attributes, and some dynamic…

### DIFF
--- a/include/cilk/cilk_api.h
+++ b/include/cilk/cilk_api.h
@@ -28,11 +28,14 @@ void __cilkrts_dprand_set_seed(uint64_t seed) __CILKRTS_NOTHROW;
 void __cilkrts_init_dprng(void) __CILKRTS_NOTHROW;
 uint64_t __cilkrts_get_dprand(void) __CILKRTS_NOTHROW;
 
-void __cilkrts_reducer_register_2(void *key, void (*reduce)(void *, void *))
-  __CILKRTS_NOTHROW;
+typedef void (__cilk_c_reduce_fn)(void *, void *);
+typedef void (__cilk_c_identity_fn)(void *);
 
-__attribute__((deprecated))
-void __cilkrts_reducer_unregister(void *key) __CILKRTS_NOTHROW;
+void __cilkrts_reducer_register_2(void *key,
+                                  __cilk_c_reduce_fn *reduce) __CILKRTS_NOTHROW;
+
+__attribute__((deprecated)) void
+__cilkrts_reducer_unregister(void *key) __CILKRTS_NOTHROW;
 
 #ifdef __cplusplus
 }

--- a/runtime/cilk-internal.h
+++ b/runtime/cilk-internal.h
@@ -23,8 +23,6 @@ extern "C" {
 #endif
 
 struct global_state;
-typedef struct global_state global_state;
-typedef struct local_state local_state;
 
 struct cilkrts_callbacks {
     unsigned last_init;
@@ -51,10 +49,10 @@ extern struct __cilkrts_status __cilkrts_status;
 
 struct __cilkrts_tls {
     __cilkrts_worker *worker;
-    struct cilk_fiber *fh;
+    cilk_fiber *fh;
 };
 
-extern __thread struct __cilkrts_tls __cilkrts_tls;
+extern thread_local struct __cilkrts_tls __cilkrts_tls;
 
 static inline __attribute__((always_inline,nothrow)) __cilkrts_worker *
 __cilkrts_get_tls_worker(void) {
@@ -113,7 +111,7 @@ struct closure_exception final : public __reducer_base {
     char *parent_rsp = nullptr;
     /* Fiber holding the stack frame of a call to _Unwind_RaiseException that is
        currently running. */
-    struct cilk_fiber *throwing_fiber = nullptr;
+    cilk_fiber *throwing_fiber = nullptr;
 
     virtual __reducer_base *identity(void *) override;
     virtual void reduce(__reducer_base *, __reducer_base *) override;
@@ -122,17 +120,16 @@ struct closure_exception final : public __reducer_base {
 
 // Reducer structure for handling exceptions thrown in parallel.
 // Retrieve the exception stored in the local view of the exception reducer.
-CHEETAH_INTERNAL struct closure_exception *
+CHEETAH_INTERNAL closure_exception *
 get_exception_reducer(__cilkrts_worker *w) noexcept;
 // Retrieve the exception stored in the local view of the exception reducer, or
 // NULL if there is no local view..
-CHEETAH_INTERNAL struct closure_exception *
+CHEETAH_INTERNAL closure_exception *
 get_exception_reducer_or_null(__cilkrts_worker *w) noexcept;
 // Free resources used for a local view of the exception reducer.  This method
 // does not deallocate the exception
-CHEETAH_INTERNAL void clear_exception_reducer(__cilkrts_worker *w,
-                                              struct closure_exception *exn_r)
-  noexcept;
+CHEETAH_INTERNAL void
+clear_exception_reducer(__cilkrts_worker *w, closure_exception *exn_r) noexcept;
 CHEETAH_INTERNAL bool exception_reducer_is_empty() noexcept;
 
 #ifdef __cplusplus

--- a/runtime/cilk2c.cpp
+++ b/runtime/cilk2c.cpp
@@ -7,11 +7,6 @@
 #include "scheduler.h"
 #include <unwind.h>
 
-extern __attribute__((noreturn))
-void _Unwind_Resume(struct _Unwind_Exception *);
-extern __attribute__((noreturn))
-_Unwind_Reason_Code _Unwind_RaiseException(struct _Unwind_Exception *);
-
 CHEETAH_INTERNAL struct cilkrts_callbacks cilkrts_callbacks = {
     0, 0, false, {nullptr}, {nullptr}};
 
@@ -62,7 +57,7 @@ void __cilkrts_check_exception_raise(__cilkrts_stack_frame *sf) {
     __cilkrts_worker *w = get_worker_from_stack(sf);
     CILK_ASSERT_POINTER_EQUAL(w, __cilkrts_get_tls_worker());
 
-    struct closure_exception *exn_r = get_exception_reducer(w);
+    closure_exception *exn_r = get_exception_reducer(w);
     char *exn = exn_r->exn;
 
     // zero exception storage, so we don't unintentionally try to
@@ -71,7 +66,7 @@ void __cilkrts_check_exception_raise(__cilkrts_stack_frame *sf) {
     sf->flags &= ~CILK_FRAME_EXCEPTION_PENDING;
 
     if (exn != nullptr) {
-        _Unwind_RaiseException((struct _Unwind_Exception *)exn); // noreturn
+        _Unwind_RaiseException((_Unwind_Exception *)exn); // noreturn
         __builtin_unreachable();
     }
 
@@ -84,7 +79,7 @@ void __cilkrts_check_exception_resume(__cilkrts_stack_frame *sf) {
     __cilkrts_worker *w = get_worker_from_stack(sf);
     CILK_ASSERT_POINTER_EQUAL(w, __cilkrts_get_tls_worker());
 
-    struct closure_exception *exn_r = get_exception_reducer(w);
+    closure_exception *exn_r = get_exception_reducer(w);
     char *exn = exn_r->exn;
 
     // zero exception storage, so we don't unintentionally try to
@@ -93,7 +88,7 @@ void __cilkrts_check_exception_resume(__cilkrts_stack_frame *sf) {
     sf->flags &= ~CILK_FRAME_EXCEPTION_PENDING;
 
     if (exn != nullptr) {
-        _Unwind_Resume((struct _Unwind_Exception *)exn); // noreturn
+        _Unwind_Resume((_Unwind_Exception *)exn); // noreturn
         __builtin_unreachable();
     }
 
@@ -104,17 +99,16 @@ void __cilkrts_check_exception_resume(__cilkrts_stack_frame *sf) {
 // of each landingpad in a spawning function.  Ensures that the stack pointer
 // points at the fiber and call-stack frame containing sf before any catch
 // handlers in that frame execute.
-extern "C"
-void __cilkrts_cleanup_fiber(__cilkrts_stack_frame *sf, int32_t sel) noexcept {
-    (void)sel; // currently unused
+extern "C" void __cilkrts_cleanup_fiber(__cilkrts_stack_frame *sf,
+                                        [[maybe_unused]] int32_t sel) noexcept {
 
     __cilkrts_worker *w = get_worker_from_stack(sf);
     CILK_ASSERT_POINTER_EQUAL(w, __cilkrts_get_tls_worker());
 
     CILK_ASSERT(__cilkrts_synced(sf));
 
-    struct closure_exception *exn_r = get_exception_reducer_or_null(w);
-    struct cilk_fiber *throwing_fiber = nullptr;
+    closure_exception *exn_r = get_exception_reducer_or_null(w);
+    cilk_fiber *throwing_fiber = nullptr;
     char *parent_rsp = nullptr;
     if (exn_r != nullptr) {
         throwing_fiber = exn_r->throwing_fiber;

--- a/runtime/cilk2c.h
+++ b/runtime/cilk2c.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-// Returns 1 if the current exection is running on Cilk workers, 0 otherwise.
+// Returns 1 if the current execution is running on Cilk workers, 0 otherwise.
 CHEETAH_API int __cilkrts_running_on_workers(void) __CILKRTS_NOTHROW;
 
 // ABI functions inlined by the compiler (provided as a bitcode file after

--- a/runtime/cilk2c_inlined.cpp
+++ b/runtime/cilk2c_inlined.cpp
@@ -7,6 +7,7 @@
 // =============================================================================
 
 #include "cilk-internal.h"
+#include "cilk/cilk_api.h"
 #include "cilk2c.h"
 #include "cilk2c_inlined.h"
 #include "debug.h"
@@ -23,15 +24,14 @@
 
 
 // Suppress -Wmissing-variable-declarations for this variable.
-_Alignas(__cilkrts_stack_frame)
-extern size_t __cilkrts_stack_frame_align;
+alignas(__cilkrts_stack_frame) extern size_t __cilkrts_stack_frame_align;
 
 // This variable encodes the alignment of a __cilkrts_stack_frame, both in its
 // value and in its own alignment.  Because LLVM IR does not associate
 // alignments with types, this variable communicates the desired alignment to
 // the compiler instead.
-_Alignas(__cilkrts_stack_frame)
-size_t __cilkrts_stack_frame_align = __alignof__(__cilkrts_stack_frame);
+alignas(__cilkrts_stack_frame) size_t __cilkrts_stack_frame_align =
+    alignof(__cilkrts_stack_frame);
 
 __attribute__((always_inline)) unsigned __cilkrts_get_nworkers(void) noexcept {
     return __cilkrts_nproc;
@@ -52,8 +52,8 @@ __reducer_base *__cilkrts_reducer_lookup_0(__reducer_base *key) {
     // If we're outside a cilkified region, then the key is the view.
     if (__cilkrts_status.need_to_cilkify)
         return key;
-    struct hyper_table *table = get_hyper_table();
-    struct bucket *b = find_hyperobject(table, (uintptr_t)key);
+    hyper_table *table = get_hyper_table();
+    bucket *b = find_hyperobject(table, (uintptr_t)key);
     if (__builtin_expect(!!b, true)) {
         // Return the reducer_base subobject of the existing view.
         // get_if is used instead of get because no exceptions are allowed
@@ -68,8 +68,8 @@ void *__cilkrts_reducer_lookup_1(void *key,
     // If we're outside a cilkified region, then the key is the view.
     if (__cilkrts_status.need_to_cilkify)
         return key;
-    struct hyper_table *table = get_hyper_table();
-    struct bucket *b = find_hyperobject(table, (uintptr_t)key);
+    hyper_table *table = get_hyper_table();
+    bucket *b = find_hyperobject(table, (uintptr_t)key);
     if (__builtin_expect(!!b, true)) {
         // Return the existing view.
         return b->data.view;
@@ -78,15 +78,14 @@ void *__cilkrts_reducer_lookup_1(void *key,
     return __cilkrts_insert_new_view_1(table, (uintptr_t)key, callbacks);
 }
 
-
 void *__cilkrts_reducer_lookup_2(void *key, size_t size,
-                                 void (*identity)(void *),
-                                 void (*reduce)(void *, void *)) {
+                                 __cilk_c_identity_fn *identity,
+                                 __cilk_c_reduce_fn *reduce) {
     // If we're outside a cilkified region, then the key is the view.
     if (__cilkrts_status.need_to_cilkify)
         return key;
-    struct hyper_table *table = get_hyper_table();
-    struct bucket *b = find_hyperobject(table, (uintptr_t)key);
+    hyper_table *table = get_hyper_table();
+    bucket *b = find_hyperobject(table, (uintptr_t)key);
     if (__builtin_expect(!!b, true)) {
         // Return the existing view.
         return b->data.view;
@@ -141,7 +140,7 @@ __cilkrts_enter_frame(__cilkrts_stack_frame *sf) noexcept {
 
     sf->magic = frame_magic;
 
-    struct cilk_fiber *fh = __cilkrts_tls.fh;
+    cilk_fiber *fh = __cilkrts_tls.fh;
     sf->fh = fh;
     sf->call_parent = fh->current_stack_frame;
     fh->current_stack_frame = sf;
@@ -149,7 +148,7 @@ __cilkrts_enter_frame(__cilkrts_stack_frame *sf) noexcept {
     // WHEN_CILK_DEBUG(sf->magic = CILK_STACKFRAME_MAGIC);
 }
 
-// Enter a spawn helper, i.e., a fucntion containing code that was cilk_spawn'd.
+// Enter a spawn helper, i.e., a function containing code that was cilk_spawn'd.
 // This function initializes worker and stack_frame structures.  Because this
 // routine will always be executed by a Cilk worker, it is optimized compared to
 // its counterpart, __cilkrts_enter_frame.
@@ -162,7 +161,7 @@ __cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf,
     sf->flags = 0;
     sf->magic = frame_magic;
 
-    struct cilk_fiber *fh = parent->fh;
+    cilk_fiber *fh = parent->fh;
     sf->fh = fh;
     if (spawner) {
         sf->call_parent = parent;
@@ -195,7 +194,7 @@ __cilkrts_detach(__cilkrts_stack_frame *sf, __cilkrts_stack_frame *parent)
     }
 
     sf->flags |= CILK_FRAME_DETACHED;
-    struct __cilkrts_stack_frame **tail = w->tail.load(std::memory_order_relaxed);
+    __cilkrts_stack_frame **tail = w->tail.load(std::memory_order_relaxed);
     CILK_ASSERT((tail + 1) < w->ltq_limit);
 
     // store parent at *tail, and then increment tail

--- a/runtime/cilk2c_inlined.h
+++ b/runtime/cilk2c_inlined.h
@@ -2,6 +2,7 @@
 // All of these use C linkage.
 
 #include "cilk/cilk_api.h"
+#include "rts-config.h"
 #include <cstdint>
 
 struct __cilkrts_stack_frame;
@@ -15,11 +16,11 @@ extern "C" {
 
 // Inserted at the entry of a spawning function that is not itself a spawn
 // helper.  Initializes the stack frame sf allocated for that function.
-void __cilkrts_enter_frame(struct __cilkrts_stack_frame *sf) __CILKRTS_NOTHROW;
+void __cilkrts_enter_frame(__cilkrts_stack_frame *sf) __CILKRTS_NOTHROW;
 // Inserted at the entry of a spawn helper, i.e., a function that must have been
 // spawned.  Initializes the stack frame sf allocated for that function.
-void __cilkrts_enter_frame_helper(struct __cilkrts_stack_frame *sf,
-                                  struct __cilkrts_stack_frame *parent,
+void __cilkrts_enter_frame_helper(__cilkrts_stack_frame *sf,
+                                  __cilkrts_stack_frame *parent,
                                   bool spawner) __CILKRTS_NOTHROW;
 
 // Prepare to perform a spawn.  This function may return once or twice,
@@ -29,42 +30,40 @@ void __cilkrts_enter_frame_helper(struct __cilkrts_stack_frame *sf,
 //   if (0 == __cilk_spawn_prepare(sf)) {
 //     spawn_helper(args);
 //   }
-int __cilk_prepare_spawn(struct __cilkrts_stack_frame *sf) __CILKRTS_NOTHROW;
+int __cilk_prepare_spawn(__cilkrts_stack_frame *sf) __CILKRTS_NOTHROW;
 
 // Called in the spawn helper immediately before the spawned computation.
 // Enables the parent function to be stollen.
-void __cilkrts_detach(struct __cilkrts_stack_frame *sf,
-                      struct __cilkrts_stack_frame *parent) __CILKRTS_NOTHROW;
+void __cilkrts_detach(__cilkrts_stack_frame *sf,
+                      __cilkrts_stack_frame *parent) __CILKRTS_NOTHROW;
 
 // Inserted on return from a spawning function that is not itself a spawn
 // helper.  Performs Cilk's return protocol for such functions.
 // Marked API because it is used inside the library by personality.cpp.
 CHEETAH_API
-void __cilkrts_leave_frame(struct __cilkrts_stack_frame *sf);
+void __cilkrts_leave_frame(__cilkrts_stack_frame *sf);
 // Inserted on return from a spawn-helper function.  Performs Cilk's return
 // protocol for such functions.
-void __cilkrts_leave_frame_helper(struct __cilkrts_stack_frame *sf,
-                                  struct __cilkrts_stack_frame *parent,
-                                  bool spawner);
+void __cilkrts_leave_frame_helper(__cilkrts_stack_frame *sf,
+                                  __cilkrts_stack_frame *parent, bool spawner);
 
 // Performs all necessary operations on return from a spawning function that is
 // not itself a spawn helper.
-void __cilk_parent_epilogue(struct __cilkrts_stack_frame *sf);
+void __cilk_parent_epilogue(__cilkrts_stack_frame *sf);
 // Performs all necessary operations on return from a spawn-helper function.
-__attribute__((always_inline))
-void __cilk_helper_epilogue(struct __cilkrts_stack_frame *sf,
-                            struct __cilkrts_stack_frame *parent,
-                            bool spawner);
-void __cilk_helper_epilogue_exn(struct __cilkrts_stack_frame *sf,
-                                struct __cilkrts_stack_frame *parent,
-                                char *exn, bool spawner);
+__attribute__((always_inline)) void
+__cilk_helper_epilogue(__cilkrts_stack_frame *sf, __cilkrts_stack_frame *parent,
+                       bool spawner);
+void __cilk_helper_epilogue_exn(__cilkrts_stack_frame *sf,
+                                __cilkrts_stack_frame *parent, char *exn,
+                                bool spawner);
 
-void __cilkrts_enter_landingpad(struct __cilkrts_stack_frame *sf, int32_t sel);
+void __cilkrts_enter_landingpad(__cilkrts_stack_frame *sf, int32_t sel);
 // Performs Cilk's return protocol on an exceptional return (i.e., a resume)
 // from a spawn-helper function.
-void __cilkrts_pause_frame(struct __cilkrts_stack_frame *sf,
-                           struct __cilkrts_stack_frame *parent,
-                           char *exn, bool spawner);
+void __cilkrts_pause_frame(__cilkrts_stack_frame *sf,
+                           __cilkrts_stack_frame *parent, char *exn,
+                           bool spawner);
 
 // Compute the grainsize for a cilk_for loop at runtime, based on the number n
 // of loop iterations.
@@ -74,27 +73,26 @@ uint32_t __cilkrts_cilk_for_grainsize_32(uint32_t n) __CILKRTS_NOTHROW;
 uint64_t __cilkrts_cilk_for_grainsize_64(uint64_t n) __CILKRTS_NOTHROW;
 
 // Performs runtime operations to handle a cilk_sync.
-void __cilk_sync(struct __cilkrts_stack_frame *sf);
+void __cilk_sync(__cilkrts_stack_frame *sf);
 
 // Implements a cilk_sync when the cilk_sync is guaranteed not to produce an
 // exception that needs to be handled locally.
-void __cilk_sync_nothrow(struct __cilkrts_stack_frame *sf);
+void __cilk_sync_nothrow(__cilkrts_stack_frame *sf);
 
 __reducer_base *__cilkrts_reducer_lookup_0(__reducer_base *key)
-  __attribute__((nonnull, returns_nonnull));
-void *__cilkrts_reducer_lookup_1(void *key, const struct __reducer_callbacks &)
-  __attribute__((nonnull, returns_nonnull));
+    __attribute__((nonnull, returns_nonnull));
+void *__cilkrts_reducer_lookup_1(void *key, const __reducer_callbacks &)
+    __attribute__((nonnull, returns_nonnull));
 void *__cilkrts_reducer_lookup_2(void *key, size_t size,
-                                 void (*id)(void *),
-                                 void (*reduce)(void *, void *))
-  __attribute__((nonnull, returns_nonnull));
+                                 __cilk_c_identity_fn *id,
+                                 __cilk_c_reduce_fn *reduce)
+    __attribute__((nonnull, returns_nonnull));
 
-void __cilkrts_reducer_register_0(__reducer_base *key)
-  __CILKRTS_NOTHROW;
-void __cilkrts_reducer_register_1(void *key, __reducer_callbacks *)
-  __CILKRTS_NOTHROW;
-void __cilkrts_reducer_register_2(void *key, void (*reduce)(void *, void *))
-  __CILKRTS_NOTHROW;
+void __cilkrts_reducer_register_0(__reducer_base *key) __CILKRTS_NOTHROW;
+void __cilkrts_reducer_register_1(void *key,
+                                  __reducer_callbacks *) __CILKRTS_NOTHROW;
+void __cilkrts_reducer_register_2(void *key,
+                                  __cilk_c_reduce_fn *reduce) __CILKRTS_NOTHROW;
 
 void __cilkrts_reducer_unregister(void *key) __CILKRTS_NOTHROW;
 

--- a/runtime/closure.h
+++ b/runtime/closure.h
@@ -25,7 +25,7 @@ enum ClosureStatus : unsigned char {
  * the children themselves, in order to avoid extra protocols
  * and locking.
  */
-struct __attribute__((visibility("hidden"))) Closure {
+struct __attribute__((visibility("hidden"))) alignas(CILK_CACHE_LINE) Closure {
     __cilkrts_stack_frame *frame; /* rest of the closure */
 
     void clear_frame() { frame = nullptr; }
@@ -33,15 +33,15 @@ struct __attribute__((visibility("hidden"))) Closure {
         CILK_ASSERT(!frame);
         frame = sf;
     }
-    struct cilk_fiber *fiber = nullptr;
-    struct cilk_fiber *fiber_child = nullptr;
+    cilk_fiber *fiber = nullptr;
+    cilk_fiber *fiber_child = nullptr;
 
-    struct cilk_fiber *ext_fiber = nullptr;
-    struct cilk_fiber *ext_fiber_child = nullptr;
+    cilk_fiber *ext_fiber = nullptr;
+    cilk_fiber *ext_fiber_child = nullptr;
 
     worker_id owner = NO_WORKER; /* debug only */
 
-    enum ClosureStatus status = CLOSURE_PRE_INVALID;
+    ClosureStatus status = CLOSURE_PRE_INVALID;
     bool exception_pending = false;
     unsigned int join_counter = 0; /* number of outstanding spawned children */
     char *orig_rsp = nullptr; /* rsp one should use when sync successfully */
@@ -58,28 +58,19 @@ struct __attribute__((visibility("hidden"))) Closure {
     hyper_table *child_ht = nullptr;
     hyper_table *user_ht = nullptr;
 
-    std::atomic<worker_id> mutex_owner
-      __attribute__((aligned(CILK_CACHE_LINE)))
-     = NO_WORKER;
+    alignas(CILK_CACHE_LINE) std::atomic<worker_id> mutex_owner = NO_WORKER;
 
-    bool has_children() const {
-        return join_counter != 0;
-    }
+    bool has_children() const { return join_counter != 0; }
 
-    void set_status(enum ClosureStatus to) {
-        status = to;
-    }
-    void change_status(enum ClosureStatus from, enum ClosureStatus to) {
+    void set_status(ClosureStatus to) { status = to; }
+    void change_status([[maybe_unused]] ClosureStatus from, ClosureStatus to) {
         CILK_ASSERT(status == from);
-        (void)from; // unused if assertions disabled
         status = to;
     }
 
     bool trylock(worker_id self);
 
-    void make_ready() {
-        status = CLOSURE_READY;
-    }
+    void make_ready() { status = CLOSURE_READY; }
 
     const char *status_to_string() const;
 
@@ -89,9 +80,9 @@ struct __attribute__((visibility("hidden"))) Closure {
     void lock(worker_id self);
     void unlock(worker_id self);
 
-    static Closure *create(struct __cilkrts_worker *, __cilkrts_stack_frame *);
-    static void destroy(Closure *, struct __cilkrts_worker *);
-    static void destroy(Closure *, struct global_state *);
+    static Closure *create(__cilkrts_worker *, __cilkrts_stack_frame *);
+    static void destroy(Closure *, __cilkrts_worker *);
+    static void destroy(Closure *, global_state *);
 
     // This method is used for sync.
     void suspend(BusyClosure *busy, worker_id self);
@@ -107,10 +98,9 @@ struct __attribute__((visibility("hidden"))) Closure {
     void assert_alienation(worker_id self);
     void checkmagic();
 
-private:
+  private:
     static void double_link_children(Closure *left, Closure *right);
     void unlink_child();
-
-} __attribute__((aligned(CILK_CACHE_LINE)));
+};
 
 #endif

--- a/runtime/debug.cpp
+++ b/runtime/debug.cpp
@@ -25,10 +25,10 @@ static char *alert_log = nullptr;
  * <code>name<\code> and the corresponding
  * <code>mask_value<\code> used by the runtime.
  **/
-typedef struct __alert_level_t {
+struct alert_level_t {
     const char *name;
     unsigned int mask_value;
-} alert_level_t;
+};
 
 /**
  * A table relating a human-readable alert level name to
@@ -194,7 +194,7 @@ extern const char __cilkrts_assertion_failed[] =
     "%s:%d: cilk assertion failed: %s\n";
 
 CHEETAH_INTERNAL_NORETURN CHEETAH_COLD
-void cilk_die_internal(struct global_state *const g, const char *fmt, ...) {
+void cilk_die_internal(global_state *const g, const char *fmt, ...) {
     fflush(stdout);
     va_list l;
     va_start(l, fmt);

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -63,7 +63,7 @@ __attribute__((__format__(__printf__, 1, 2)))
 CHEETAH_INTERNAL_NORETURN CHEETAH_COLD
 void cilkrts_bug(const char *fmt, ...);
 CHEETAH_INTERNAL_NORETURN CHEETAH_COLD
-void cilk_die_internal(struct global_state *const g, const char *fmt, ...);
+void cilk_die_internal(global_state *const g, const char *fmt, ...);
 
 #if ALERT_LVL != 0
 __attribute__((__format__(__printf__, 2, 3))) void
@@ -132,6 +132,4 @@ CHEETAH_INTERNAL extern const char __cilkrts_assertion_failed[];
 #define WHEN_CILK_DEBUG(ex)
 #endif // CILK_DEBUG
 
-// to silence compiler warning for vars only used during debugging
-#define USE_UNUSED(var) (void)(var)
 #endif

--- a/runtime/efficiency.h
+++ b/runtime/efficiency.h
@@ -17,7 +17,7 @@ typedef uint32_t history_sample_t;
 // worker state.  ATTEMPTS must divide SENTINEL_THRESHOLD.
 #define ATTEMPTS 4
 
-typedef struct history_t {
+struct history_t {
     history_sample_t inefficient_history = 0;
     history_sample_t efficient_history = 0;
     unsigned int sentinel_count_history_tail = 0;
@@ -25,6 +25,6 @@ typedef struct history_t {
     unsigned int fails = 0; // rts->init_fails(...);
     unsigned int sample_threshold = SENTINEL_THRESHOLD;
     unsigned int sentinel_count_history[SENTINEL_COUNT_HISTORY] = { 1 };
-} history_t;
+};
 
 #endif

--- a/runtime/fiber-header.h
+++ b/runtime/fiber-header.h
@@ -9,11 +9,11 @@ struct __cilkrts_stack_frame;
 // Structure inserted at the top of a fiber, to implement fiber-local storage.
 // The stack begins just below this structure.  See get_stack_start().
 // This must be a standard layout class.
-struct cilk_fiber {
+struct alignas(CILK_CACHE_LINE) cilk_fiber {
     // Worker currently executing on the fiber.
-    struct __cilkrts_worker *worker;
+    __cilkrts_worker *worker;
     // Current stack frame executing on the fiber.
-    struct __cilkrts_stack_frame *current_stack_frame;
+    __cilkrts_stack_frame *current_stack_frame;
 
     // NOTE: The current hyper_table can be stored in the fiber header, but we
     // don't currently observe any performance advantage or disadvantage to
@@ -25,8 +25,8 @@ struct cilk_fiber {
 
     // These next two words are for internal library use and are
     // constant for the life of this structure.
-    char *alloc_low;         // lowest byte of mapped region
-    char *stack_low;         // lowest byte of stack region
+    char *alloc_low; // lowest byte of mapped region
+    char *stack_low; // lowest byte of stack region
 
     // Three unused words remain on 64 bit systems with 64 byte cache lines.
 
@@ -45,7 +45,6 @@ struct cilk_fiber {
         current_stack_frame = nullptr;
         fake_stack_save = nullptr;
     }
-
-} __attribute__((aligned(CILK_CACHE_LINE)));
+};
 
 #endif // _FIBER_HEADER_H

--- a/runtime/fiber-pool.cpp
+++ b/runtime/fiber-pool.cpp
@@ -36,7 +36,7 @@
 // Private helper functions for maintaining pool stats
 //=========================================================
 
-static void fiber_pool_stat_init(struct cilk_fiber_pool *pool) {
+static void fiber_pool_stat_init(cilk_fiber_pool *pool) {
     pool->stats.in_use = 0;
     pool->stats.max_in_use = 0;
     pool->stats.max_free = 0;
@@ -51,7 +51,7 @@ static void fiber_pool_stat_print_worker(__cilkrts_worker *w, void *data) {
             w->l->fiber_pool.stats.max_in_use, w->l->fiber_pool.stats.max_free);
 }
 
-static void fiber_pool_stat_print(struct global_state *g) {
+static void fiber_pool_stat_print(global_state *g) {
     fprintf(stderr, "\nFIBER POOL STATS\n[G  ] " POOL_FMT "\n",
             g->fiber_pool.size, g->fiber_pool.stats.in_use,
             g->fiber_pool.stats.max_in_use, g->fiber_pool.stats.max_free);
@@ -64,17 +64,15 @@ static void fiber_pool_stat_print(struct global_state *g) {
 //=========================================================
 
 // forward decl
-static void fiber_pool_allocate_batch(worker_id self,
-                                      struct cilk_fiber_pool *pool,
+static void fiber_pool_allocate_batch(worker_id self, cilk_fiber_pool *pool,
                                       unsigned int num_to_allocate);
-static void fiber_pool_free_batch(worker_id self,
-                                  struct cilk_fiber_pool *pool,
+static void fiber_pool_free_batch(worker_id self, cilk_fiber_pool *pool,
                                   unsigned int num_to_free);
 
 /* Helper function for initializing fiber pool */
-static void fiber_pool_init(struct cilk_fiber_pool *pool, size_t stacksize,
-                            unsigned int bufsize,
-                            struct cilk_fiber_pool *parent, int is_shared) {
+static void fiber_pool_init(cilk_fiber_pool *pool, size_t stacksize,
+                            unsigned int bufsize, cilk_fiber_pool *parent,
+                            int is_shared) {
     cilk_mutex_init(&pool->lock);
     pool->mutex_owner = NO_WORKER;
     pool->shared = is_shared;
@@ -83,11 +81,11 @@ static void fiber_pool_init(struct cilk_fiber_pool *pool, size_t stacksize,
     pool->capacity = bufsize;
     pool->size = 0;
     pool->fibers =
-      static_cast<struct cilk_fiber **>(calloc(bufsize, sizeof(*pool->fibers)));
+        static_cast<cilk_fiber **>(calloc(bufsize, sizeof(*pool->fibers)));
 }
 
 /* Helper function for destroying fiber pool */
-static void fiber_pool_destroy(struct cilk_fiber_pool *pool) {
+static void fiber_pool_destroy(cilk_fiber_pool *pool) {
     CILK_ASSERT(pool->size == 0);
     cilk_mutex_destroy(&pool->lock);
     // pool->fibers might be NULL if the fiber pool was never actually
@@ -100,19 +98,18 @@ static void fiber_pool_destroy(struct cilk_fiber_pool *pool) {
 }
 
 static inline void fiber_pool_assert_ownership(worker_id self,
-                                               struct cilk_fiber_pool *pool) {
+                                               cilk_fiber_pool *pool) {
     if (pool->shared)
         CILK_ASSERT(pool->mutex_owner == self);
 }
 
 static inline void fiber_pool_assert_alienation(worker_id self,
-                                                struct cilk_fiber_pool *pool) {
+                                                cilk_fiber_pool *pool) {
     if (pool->shared)
         CILK_ASSERT(pool->mutex_owner != self);
 }
 
-static inline void fiber_pool_lock(worker_id self,
-                                   struct cilk_fiber_pool *pool) {
+static inline void fiber_pool_lock(worker_id self, cilk_fiber_pool *pool) {
     if (pool->shared) {
         fiber_pool_assert_alienation(self, pool);
         cilk_mutex_lock(&pool->lock);
@@ -120,8 +117,7 @@ static inline void fiber_pool_lock(worker_id self,
     }
 }
 
-static inline void fiber_pool_unlock(worker_id self,
-                                     struct cilk_fiber_pool *pool) {
+static inline void fiber_pool_unlock(worker_id self, cilk_fiber_pool *pool) {
     if (pool->shared) {
         fiber_pool_assert_ownership(self, pool);
         pool->mutex_owner = NO_WORKER;
@@ -134,16 +130,14 @@ static inline void fiber_pool_unlock(worker_id self,
  * already larger than the new size, do nothing.  Assume lock acquired upon
  * entry.
  */
-static void fiber_pool_increase_capacity(worker_id self,
-                                         struct cilk_fiber_pool *pool,
+static void fiber_pool_increase_capacity(worker_id self, cilk_fiber_pool *pool,
                                          unsigned int new_size) {
 
     fiber_pool_assert_ownership(self, pool);
 
     if (pool->capacity < new_size) {
-        struct cilk_fiber **larger =
-            static_cast<struct cilk_fiber **>
-                (realloc(pool->fibers, new_size * sizeof(*pool->fibers)));
+        cilk_fiber **larger = static_cast<cilk_fiber **>(
+            realloc(pool->fibers, new_size * sizeof(*pool->fibers)));
         if (!larger)
             CILK_ABORT("out of fiber memory");
         pool->fibers = larger;
@@ -156,10 +150,9 @@ static void fiber_pool_increase_capacity(worker_id self,
  * already smaller than the new size, do nothing.  Assume lock acquired upon
  * entry.
  */
-__attribute__((unused)) // unused for now
-static void
-fiber_pool_decrease_capacity(worker_id self, struct cilk_fiber_pool *pool,
-                             unsigned int new_size) {
+[[maybe_unused]] // unused for now
+static void fiber_pool_decrease_capacity(worker_id self, cilk_fiber_pool *pool,
+                                         unsigned int new_size) {
 
     fiber_pool_assert_ownership(self, pool);
 
@@ -169,8 +162,8 @@ fiber_pool_decrease_capacity(worker_id self, struct cilk_fiber_pool *pool,
         CILK_ASSERT(pool->size == new_size);
     }
     if (pool->capacity > new_size) {
-        struct cilk_fiber **smaller = (struct cilk_fiber **)realloc(
-            pool->fibers, new_size * sizeof(struct cilk_fiber *));
+        cilk_fiber **smaller = (cilk_fiber **)realloc(
+            pool->fibers, new_size * sizeof(cilk_fiber *));
         if (smaller) {
             pool->fibers = smaller;
             pool->capacity = new_size;
@@ -183,8 +176,7 @@ fiber_pool_decrease_capacity(worker_id self, struct cilk_fiber_pool *pool,
  * We will first look into the parent pool, and if the parent pool does not
  * have enough, we then get it from the system.
  */
-static void fiber_pool_allocate_batch(worker_id self,
-                                      struct cilk_fiber_pool *pool,
+static void fiber_pool_allocate_batch(worker_id self, cilk_fiber_pool *pool,
                                       const unsigned int batch_size) {
 
     fiber_pool_assert_ownership(self, pool);
@@ -192,7 +184,7 @@ static void fiber_pool_allocate_batch(worker_id self,
 
     unsigned int from_parent = 0;
     if (pool->parent) {
-        struct cilk_fiber_pool *parent = pool->parent;
+        cilk_fiber_pool *parent = pool->parent;
         fiber_pool_lock(self, parent);
         from_parent = parent->size <= batch_size ? parent->size : batch_size;
         for (unsigned int i = 0; i < from_parent; i++) {
@@ -207,8 +199,7 @@ static void fiber_pool_allocate_batch(worker_id self,
     }
     if (batch_size > from_parent) { // if we need more still
         for (unsigned int i = from_parent; i < batch_size; i++) {
-            pool->fibers[pool->size++] =
-                cilk_fiber_allocate(pool->stack_size);
+            pool->fibers[pool->size++] = cilk_fiber_allocate(pool->stack_size);
         }
     }
     if (pool->size > pool->stats.max_free) {
@@ -220,15 +211,14 @@ static void fiber_pool_allocate_batch(worker_id self,
  * Free num_to_free fibers from this pool back to either the parent
  * or the system.
  */
-static void fiber_pool_free_batch(worker_id self,
-                                  struct cilk_fiber_pool *pool,
+static void fiber_pool_free_batch(worker_id self, cilk_fiber_pool *pool,
                                   const unsigned int batch_size) {
     fiber_pool_assert_ownership(self, pool);
     CILK_ASSERT(batch_size <= pool->size);
 
     unsigned int to_parent = 0;
     if (pool->parent) { // first try to free into the parent
-        struct cilk_fiber_pool *parent = pool->parent;
+        cilk_fiber_pool *parent = pool->parent;
         fiber_pool_lock(self, parent);
         to_parent = (batch_size <= (parent->capacity - parent->size))
                         ? batch_size
@@ -246,7 +236,7 @@ static void fiber_pool_free_batch(worker_id self,
     }
     if ((batch_size - to_parent) > 0) { // still need to free more
         for (unsigned int i = to_parent; i < batch_size; i++) {
-            struct cilk_fiber *fiber = pool->fibers[--pool->size];
+            cilk_fiber *fiber = pool->fibers[--pool->size];
             cilk_fiber_deallocate(fiber);
         }
     }
@@ -260,9 +250,8 @@ static void fiber_pool_free_batch(worker_id self,
 void cilk_fiber_pool_global_init(global_state *g) {
 
     unsigned int bufsize = g->options.nproc * g->options.fiber_pool_cap;
-    struct cilk_fiber_pool *pool = &(g->fiber_pool);
-    fiber_pool_init(pool, g->options.stacksize, bufsize,
-                    nullptr, 1 /*shared*/);
+    cilk_fiber_pool *pool = &(g->fiber_pool);
+    fiber_pool_init(pool, g->options.stacksize, bufsize, nullptr, 1 /*shared*/);
     CILK_ASSERT(nullptr != pool->fibers);
     fiber_pool_stat_init(pool);
     /* let's not preallocate for global fiber pool for now */
@@ -272,10 +261,10 @@ void cilk_fiber_pool_global_init(global_state *g) {
  * stats and print them out (if FIBER_STATS is set)
  */
 void cilk_fiber_pool_global_terminate(global_state *g) {
-    struct cilk_fiber_pool *pool = &g->fiber_pool;
+    cilk_fiber_pool *pool = &g->fiber_pool;
     cilk_mutex_lock(&pool->lock); /* probably not needed */
     while (pool->size > 0) {
-        struct cilk_fiber *fiber = pool->fibers[--pool->size];
+        cilk_fiber *fiber = pool->fibers[--pool->size];
         cilk_fiber_deallocate_global(g, fiber);
     }
     cilk_mutex_unlock(&pool->lock);
@@ -297,7 +286,7 @@ void cilk_fiber_pool_global_destroy(global_state *g) {
  * cilk_fiber_pool_per_worker_destroy() to succeed.
  */
 void cilk_fiber_pool_per_worker_zero_init(__cilkrts_worker *w) {
-    struct cilk_fiber_pool *pool = &(w->l->fiber_pool);
+    cilk_fiber_pool *pool = &(w->l->fiber_pool);
     pool->size = 0;
     pool->fibers = nullptr;
 }
@@ -310,7 +299,7 @@ void cilk_fiber_pool_per_worker_init(__cilkrts_worker *w) {
 
     global_state *g = w->g;
     unsigned int bufsize = g->options.fiber_pool_cap;
-    struct cilk_fiber_pool *pool = &(w->l->fiber_pool);
+    cilk_fiber_pool *pool = &(w->l->fiber_pool);
     fiber_pool_init(pool, g->options.stacksize, bufsize, &(g->fiber_pool),
                     0 /* private */);
     CILK_ASSERT(nullptr != pool->fibers);
@@ -324,10 +313,10 @@ void cilk_fiber_pool_per_worker_init(__cilkrts_worker *w) {
  * stats and print them out (if FIBER_STATS is set)
  */
 void cilk_fiber_pool_per_worker_terminate(__cilkrts_worker *w) {
-    struct cilk_fiber_pool *pool = &(w->l->fiber_pool);
+    cilk_fiber_pool *pool = &(w->l->fiber_pool);
     while (pool->size > 0) {
         unsigned index = --pool->size;
-        struct cilk_fiber *fiber = pool->fibers[index];
+        cilk_fiber *fiber = pool->fibers[index];
         pool->fibers[index] = nullptr;
         cilk_fiber_deallocate(fiber);
     }
@@ -336,7 +325,7 @@ void cilk_fiber_pool_per_worker_terminate(__cilkrts_worker *w) {
 /* Per-worker fiber pool clean up. */
 void cilk_fiber_pool_per_worker_destroy(__cilkrts_worker *w) {
 
-    struct cilk_fiber_pool *pool = &(w->l->fiber_pool);
+    cilk_fiber_pool *pool = &(w->l->fiber_pool);
     fiber_pool_destroy(pool);
 }
 
@@ -344,13 +333,13 @@ void cilk_fiber_pool_per_worker_destroy(__cilkrts_worker *w) {
  * Allocate a fiber from this pool; if this pool is empty,
  * allocate a batch of fibers from the parent pool (or system).
  */
-struct cilk_fiber *cilk_fiber_allocate_from_pool(__cilkrts_worker *w) {
-    struct cilk_fiber_pool *pool = &(w->l->fiber_pool);
+cilk_fiber *cilk_fiber_allocate_from_pool(__cilkrts_worker *w) {
+    cilk_fiber_pool *pool = &(w->l->fiber_pool);
     if (pool->size == 0) {
         fiber_pool_allocate_batch(w->self, pool,
                                   pool->capacity / BATCH_FRACTION);
     }
-    struct cilk_fiber *ret = pool->fibers[--pool->size];
+    cilk_fiber *ret = pool->fibers[--pool->size];
     pool->stats.in_use++;
     if (pool->stats.in_use > pool->stats.max_in_use) {
         pool->stats.max_in_use = pool->stats.in_use;
@@ -366,14 +355,14 @@ struct cilk_fiber *cilk_fiber_allocate_from_pool(__cilkrts_worker *w) {
  * free a batch of fibers back into the parent pool (or system).
  */
 void cilk_fiber_deallocate_to_pool(__cilkrts_worker *w,
-                                   struct cilk_fiber *fiber_to_return) {
+                                   cilk_fiber *fiber_to_return) {
     if (fiber_to_return)
         sanitizer_poison_fiber(fiber_to_return);
-    struct cilk_fiber_pool *pool = &(w->l->fiber_pool);
+    cilk_fiber_pool *pool = &(w->l->fiber_pool);
     if (pool->size == pool->capacity) {
         fiber_pool_free_batch(w->self, pool, pool->capacity / BATCH_FRACTION);
         CILK_ASSERT((pool->capacity - pool->size) >=
-                           (pool->capacity / BATCH_FRACTION));
+                    (pool->capacity / BATCH_FRACTION));
     }
     if (fiber_to_return) {
         fiber_to_return->clear();

--- a/runtime/fiber.cpp
+++ b/runtime/fiber.cpp
@@ -17,7 +17,6 @@
 #include "fiber-header.h"
 #include "fiber.h"
 
-
 /* Set up flags for mmap to allocate a stack region.
 
    Darwin does not have any special support for mapping stacks and
@@ -42,11 +41,10 @@
 #define MAP_GROWSDOWN 0
 #endif
 #ifdef MAP_STACK
-#define MAP_STACK_FLAGS \
-  (MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK | MAP_GROWSDOWN)
+#define MAP_STACK_FLAGS                                                        \
+    (MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK | MAP_GROWSDOWN)
 #else
-#define MAP_STACK_FLAGS \
-  (MAP_PRIVATE | MAP_ANONYMOUS)
+#define MAP_STACK_FLAGS (MAP_PRIVATE | MAP_ANONYMOUS)
 #endif
 
 //===============================================================
@@ -73,7 +71,7 @@ static void __asan_unpoison_memory_region_weak(const void volatile *addr,
                                                size_t size)
     __attribute__((__weakref__("__asan_unpoison_memory_region")));
 static void __asan_poison_memory_region_weak(const void volatile *addr,
-                                               size_t size)
+                                             size_t size)
     __attribute__((__weakref__("__asan_poison_memory_region")));
 
 typedef void (*SanitizerStartSwitchFiberFuncPtr)(void **, const void *, size_t);
@@ -86,16 +84,18 @@ static bool have_sanitizer_start_switch_fiber_fn = false;
 static bool have_sanitizer_finish_switch_fiber_fn = false;
 static bool have_asan_unpoison_memory_region_fn = false;
 static bool have_asan_poison_memory_region_fn = false;
-static SanitizerStartSwitchFiberFuncPtr sanitizer_start_switch_fiber_fn = nullptr;
-static SanitizerFinishSwitchFiberFuncPtr sanitizer_finish_switch_fiber_fn = nullptr;
+static SanitizerStartSwitchFiberFuncPtr sanitizer_start_switch_fiber_fn =
+    nullptr;
+static SanitizerFinishSwitchFiberFuncPtr sanitizer_finish_switch_fiber_fn =
+    nullptr;
 static AsanPoisonMemoryRegionFuncPtr asan_poison_memory_region_fn = nullptr;
 static AsanUnpoisonMemoryRegionFuncPtr asan_unpoison_memory_region_fn = nullptr;
 
-static __thread void *fake_stack_save = nullptr;
-static const __thread void *old_thread_stack = nullptr;
-static __thread size_t old_thread_stacksize = 0;
-static __thread struct cilk_fiber *current_fiber = nullptr;
-static __thread bool on_fiber = false;
+static thread_local void *fake_stack_save = nullptr;
+static const thread_local void *old_thread_stack = nullptr;
+static thread_local size_t old_thread_stacksize = 0;
+static thread_local cilk_fiber *current_fiber = nullptr;
+static thread_local bool on_fiber = false;
 
 static SanitizerStartSwitchFiberFuncPtr getStartSwitchFiberFunc() {
     SanitizerStartSwitchFiberFuncPtr fn = nullptr;
@@ -107,7 +107,7 @@ static SanitizerStartSwitchFiberFuncPtr getStartSwitchFiberFunc() {
 
     // Check whether we can find a dynamically linked function.
     if (nullptr != (fn = (SanitizerStartSwitchFiberFuncPtr)dlsym(
-                     RTLD_DEFAULT, "__sanitizer_start_switch_fiber"))) {
+                        RTLD_DEFAULT, "__sanitizer_start_switch_fiber"))) {
         return fn;
     }
 
@@ -125,7 +125,7 @@ static SanitizerFinishSwitchFiberFuncPtr getFinishSwitchFiberFunc() {
 
     // Check whether we can find a dynamically linked function.
     if (nullptr != (fn = (SanitizerFinishSwitchFiberFuncPtr)dlsym(
-                     RTLD_DEFAULT, "__sanitizer_finish_switch_fiber"))) {
+                        RTLD_DEFAULT, "__sanitizer_finish_switch_fiber"))) {
         return fn;
     }
 
@@ -143,7 +143,7 @@ static AsanPoisonMemoryRegionFuncPtr getPoisonMemoryRegionFunc() {
 
     // Check whether we can find a dynamically linked function.
     if (nullptr != (fn = (AsanPoisonMemoryRegionFuncPtr)dlsym(
-                         RTLD_DEFAULT, "__asan_poison_memory_region"))) {
+                        RTLD_DEFAULT, "__asan_poison_memory_region"))) {
         return fn;
     }
 
@@ -161,7 +161,7 @@ static AsanUnpoisonMemoryRegionFuncPtr getUnpoisonMemoryRegionFunc() {
 
     // Check whether we can find a dynamically linked function.
     if (nullptr != (fn = (AsanUnpoisonMemoryRegionFuncPtr)dlsym(
-                         RTLD_DEFAULT, "__asan_unpoison_memory_region"))) {
+                        RTLD_DEFAULT, "__asan_unpoison_memory_region"))) {
         return fn;
     }
 
@@ -169,7 +169,7 @@ static AsanUnpoisonMemoryRegionFuncPtr getUnpoisonMemoryRegionFunc() {
     return nullptr;
 }
 
-void sanitizer_start_switch_fiber(struct cilk_fiber *fiber) __CILKRTS_NOTHROW {
+void sanitizer_start_switch_fiber(cilk_fiber *fiber) __CILKRTS_NOTHROW {
     if (!have_sanitizer_start_switch_fiber_fn) {
         sanitizer_start_switch_fiber_fn = getStartSwitchFiberFunc();
         have_sanitizer_start_switch_fiber_fn = true;
@@ -199,9 +199,9 @@ void sanitizer_start_switch_fiber(struct cilk_fiber *fiber) __CILKRTS_NOTHROW {
             if (current_fiber) {
                 // The worker is currently in Cilk user code.  Save the
                 // fake_stack for the current fiber in that fiber's header.
-                sanitizer_start_switch_fiber_fn(
-                    &current_fiber->fake_stack_save,
-                    old_thread_stack, old_thread_stacksize);
+                sanitizer_start_switch_fiber_fn(&current_fiber->fake_stack_save,
+                                                old_thread_stack,
+                                                old_thread_stacksize);
                 // Clear the current fiber.
                 current_fiber = nullptr;
             } else {
@@ -228,16 +228,16 @@ void sanitizer_finish_switch_fiber() __CILKRTS_NOTHROW {
                 // The worker switched into Cilk user code from outside.  Save
                 // the old stack's parameters in old_thread_stack and
                 // old_thread_stacksave.
-                sanitizer_finish_switch_fiber_fn(
-                    current_fiber->fake_stack_save,
-                    &old_thread_stack, &old_thread_stacksize);
+                sanitizer_finish_switch_fiber_fn(current_fiber->fake_stack_save,
+                                                 &old_thread_stack,
+                                                 &old_thread_stacksize);
                 // Record that the worker is not in Cilk user code.
                 on_fiber = true;
             } else {
                 // The worker is remaining in Cilk user code.  Don't save the
                 // old stack's parameters.
-                sanitizer_finish_switch_fiber_fn(
-                    current_fiber->fake_stack_save, nullptr, nullptr);
+                sanitizer_finish_switch_fiber_fn(current_fiber->fake_stack_save,
+                                                 nullptr, nullptr);
             }
         } else {
             // The worker switched out of Cilk user cude.  Restore the
@@ -249,27 +249,27 @@ void sanitizer_finish_switch_fiber() __CILKRTS_NOTHROW {
     }
 }
 
-void sanitizer_unpoison_fiber(struct cilk_fiber *fiber) {
+void sanitizer_unpoison_fiber(cilk_fiber *fiber) {
     if (!have_asan_unpoison_memory_region_fn) {
         asan_unpoison_memory_region_fn = getUnpoisonMemoryRegionFunc();
         have_asan_unpoison_memory_region_fn = true;
     }
     if (nullptr != asan_unpoison_memory_region_fn) {
         char *stack_high = fiber->get_stack_start();
-        asan_unpoison_memory_region_fn(
-            fiber->stack_low, (size_t)(stack_high - fiber->stack_low));
+        asan_unpoison_memory_region_fn(fiber->stack_low,
+                                       (size_t)(stack_high - fiber->stack_low));
     }
 }
 
-void sanitizer_poison_fiber(struct cilk_fiber *fiber) {
+void sanitizer_poison_fiber(cilk_fiber *fiber) {
     if (!have_asan_poison_memory_region_fn) {
         asan_poison_memory_region_fn = getPoisonMemoryRegionFunc();
         have_asan_poison_memory_region_fn = true;
     }
     if (nullptr != asan_poison_memory_region_fn) {
         char *stack_high = fiber->get_stack_start();
-        asan_poison_memory_region_fn(
-            fiber->stack_low, (size_t)(stack_high - fiber->stack_low));
+        asan_poison_memory_region_fn(fiber->stack_low,
+                                     (size_t)(stack_high - fiber->stack_low));
     }
 }
 #endif // CILK_ENABLE_ASAN_HOOKS
@@ -278,7 +278,7 @@ void sanitizer_poison_fiber(struct cilk_fiber *fiber) {
 // Private helper functions
 //===============================================================
 
-struct cilk_fiber *make_stack(size_t stack_size) {
+cilk_fiber *make_stack(size_t stack_size) {
     const int page_shift = cheetah_page_shift;
     const size_t page_size = 1U << page_shift;
 
@@ -289,9 +289,9 @@ struct cilk_fiber *make_stack(size_t stack_size) {
     } else if (stack_pages > MAX_NUM_PAGES_PER_STACK) {
         stack_pages = MAX_NUM_PAGES_PER_STACK;
     }
-    char *alloc_low = (char *)mmap(
-        0, stack_pages * page_size, PROT_READ | PROT_WRITE,
-        MAP_STACK_FLAGS, -1, 0);
+    char *alloc_low =
+        (char *)mmap(0, stack_pages * page_size, PROT_READ | PROT_WRITE,
+                     MAP_STACK_FLAGS, -1, 0);
     if (MAP_FAILED == alloc_low) {
         cilkrts_bug(nullptr, "Cilk: stack mmap failed");
         /* Currently unreached.  TODO: Investigate more graceful
@@ -300,11 +300,11 @@ struct cilk_fiber *make_stack(size_t stack_size) {
     }
     char *alloc_high = alloc_low + stack_pages * page_size;
     char *stack_low = alloc_low + page_size;
-    char *stack_high = alloc_high - sizeof(struct cilk_fiber);
+    char *stack_high = alloc_high - sizeof(cilk_fiber);
 #ifndef MAP_STACK
     (void)mprotect(alloc_low, page_size, PROT_NONE);
 #endif
-    struct cilk_fiber *f = (struct cilk_fiber *)stack_high;
+    cilk_fiber *f = (cilk_fiber *)stack_high;
     f->alloc_low = alloc_low;
     f->stack_low = stack_low;
     if (DEBUG_ENABLED(MEMORY_SLOW))
@@ -312,7 +312,7 @@ struct cilk_fiber *make_stack(size_t stack_size) {
     return f;
 }
 
-static void free_stack(struct cilk_fiber *f) {
+static void free_stack(cilk_fiber *f) {
     if (DEBUG_ENABLED(MEMORY_SLOW)) {
         char *stack_low = f->stack_low;
         char *stack_high = f->get_stack_start();
@@ -329,30 +329,25 @@ static void free_stack(struct cilk_fiber *f) {
 // Supported public functions
 //===============================================================
 
-struct cilk_fiber *cilk_fiber_allocate(size_t stacksize) {
-    struct cilk_fiber *fiber = make_stack(stacksize);
+cilk_fiber *cilk_fiber_allocate(size_t stacksize) {
+    cilk_fiber *fiber = make_stack(stacksize);
     fiber->clear();
     cilkrts_alert(FIBER, "Allocate fiber %p [%p--%p]", (void *)fiber,
-                  (void *)fiber->stack_low,
-                  (void *)fiber->get_stack_start());
+                  (void *)fiber->stack_low, (void *)fiber->get_stack_start());
     return fiber;
 }
 
-void cilk_fiber_deallocate(struct cilk_fiber *fiber) {
+void cilk_fiber_deallocate(cilk_fiber *fiber) {
     cilkrts_alert(FIBER, "Deallocate fiber %p [%p--%p]", (void *)fiber,
-                  (void *)fiber->stack_low,
-                  (void *)fiber->get_stack_start());
+                  (void *)fiber->stack_low, (void *)fiber->get_stack_start());
     if (DEBUG_ENABLED_STATIC(FIBER))
         CILK_ASSERT(!fiber->in_fiber(fiber->current_stack_frame));
     free_stack(fiber);
 }
 
-void cilk_fiber_deallocate_global(struct global_state *g,
-                                  struct cilk_fiber *fiber) {
-    (void)g; // not currently used
-
+void cilk_fiber_deallocate_global([[maybe_unused]] global_state *g,
+                                  cilk_fiber *fiber) {
     cilkrts_alert(FIBER, "Deallocate fiber %p [%p--%p]", (void *)fiber,
-                  (void *)fiber->stack_low,
-                  (void *)fiber->get_stack_start());
+                  (void *)fiber->stack_low, (void *)fiber->get_stack_start());
     free_stack(fiber);
 }

--- a/runtime/fiber.h
+++ b/runtime/fiber.h
@@ -23,24 +23,24 @@ struct fiber_pool_stats {
 struct cilk_fiber_pool {
     worker_id mutex_owner;
     int shared;
-    size_t stack_size;              // Size of stacks for fibers in this pool.
-    struct cilk_fiber_pool *parent; // Parent pool.
-                                    // If this pool is empty, get from parent
+    size_t stack_size;       // Size of stacks for fibers in this pool.
+    cilk_fiber_pool *parent; // Parent pool.
+                             // If this pool is empty, get from parent
     // Describes inactive fibers stored in the pool.
-    struct cilk_fiber **fibers; // Array of max_size fiber pointers
-    unsigned int capacity;      // Limit on number of fibers in pool
-    unsigned int size;          // Number of fibers currently in the pool
-    struct fiber_pool_stats stats;
+    cilk_fiber **fibers;   // Array of max_size fiber pointers
+    unsigned int capacity; // Limit on number of fibers in pool
+    unsigned int size;     // Number of fibers currently in the pool
+    fiber_pool_stats stats;
 
-    cilk_mutex lock __attribute__((aligned(CILK_CACHE_LINE)));
+    alignas(CILK_CACHE_LINE) cilk_mutex lock;
 };
 
 //===============================================================
 // Supported functions
 //===============================================================
 
-static inline __attribute__((always_inline,nothrow)) void
-sysdep_save_fp_ctrl_state(__cilkrts_stack_frame *sf) {
+static inline __attribute__((always_inline, nothrow)) void
+sysdep_save_fp_ctrl_state([[maybe_unused]] __cilkrts_stack_frame *sf) {
 #ifdef CHEETAH_SAVE_MXCSR
 #if 1
     __asm__("stmxcsr %0" : "=m"(MXCSR(sf)));
@@ -49,7 +49,7 @@ sysdep_save_fp_ctrl_state(__cilkrts_stack_frame *sf) {
     sf->mxcsr = __builtin_ia32_stmxcsr(); /* aka _mm_setcsr */
 #endif
 #else
-    (void)sf; // intentionally unused
+    // sf intentionally unused
 #endif
 }
 
@@ -58,8 +58,8 @@ sysdep_save_fp_ctrl_state(__cilkrts_stack_frame *sf) {
  * spawn.  This should be called each time a frame is resumed.  OpenCilk
  * only saves MXCSR.  The 80387 status word is obsolete.
  */
-static inline __attribute__((always_inline,nothrow)) void
-sysdep_restore_fp_state(__cilkrts_stack_frame *sf) {
+static inline __attribute__((always_inline, nothrow)) void
+sysdep_restore_fp_state([[maybe_unused]] __cilkrts_stack_frame *sf) {
     /* TODO: Find a way to do this only when using floating point. */
 #ifdef CHEETAH_SAVE_MXCSR
 #if 1
@@ -69,7 +69,7 @@ sysdep_restore_fp_state(__cilkrts_stack_frame *sf) {
     __builtin_ia32_ldmxcsr(sf->mxcsr); /* aka _mm_getcsr */
 #endif
 #else
-    (void)sf; // intentionally unused
+    // sf intentionally unused
 #endif
 
 #ifdef __AVX__
@@ -80,7 +80,7 @@ sysdep_restore_fp_state(__cilkrts_stack_frame *sf) {
 #endif
 }
 
-static inline char *sysdep_reset_stack_for_resume(struct cilk_fiber *fiber,
+static inline char *sysdep_reset_stack_for_resume(cilk_fiber *fiber,
                                                   __cilkrts_stack_frame *sf) {
     CILK_ASSERT(fiber);
     char *sp = fiber->get_stack_start();
@@ -91,10 +91,10 @@ static inline char *sysdep_reset_stack_for_resume(struct cilk_fiber *fiber,
     return sp;
 }
 
-static inline __attribute__((noreturn))
-void sysdep_longjmp_to_sf(__cilkrts_stack_frame *sf) {
-    cilkrts_alert(FIBER,
-                  "longjmp to sf, BP/SP/PC: %p/%p/%p", FP(sf), SP(sf), PC(sf));
+static inline __attribute__((noreturn)) void
+sysdep_longjmp_to_sf(__cilkrts_stack_frame *sf) {
+    cilkrts_alert(FIBER, "longjmp to sf, BP/SP/PC: %p/%p/%p", FP(sf), SP(sf),
+                  PC(sf));
 
 #if defined CHEETAH_SAVE_MXCSR
     // Restore the floating point state that was set in this frame at the
@@ -114,33 +114,28 @@ CHEETAH_INTERNAL void cilk_fiber_pool_per_worker_destroy(__cilkrts_worker *w);
 
 // allocate / deallocate one fiber from / back to OS
 CHEETAH_INTERNAL
-struct cilk_fiber *cilk_fiber_allocate(size_t stacksize);
+cilk_fiber *cilk_fiber_allocate(size_t stacksize);
 CHEETAH_INTERNAL
-void cilk_fiber_deallocate(struct cilk_fiber *fiber);
+void cilk_fiber_deallocate(cilk_fiber *fiber);
 CHEETAH_INTERNAL
-void cilk_fiber_deallocate_global(global_state *, struct cilk_fiber *fiber);
+void cilk_fiber_deallocate_global(global_state *, cilk_fiber *fiber);
 // allocate / deallocate one fiber from / back to per-worker pool
 CHEETAH_INTERNAL
-struct cilk_fiber *cilk_fiber_allocate_from_pool(__cilkrts_worker *w);
+cilk_fiber *cilk_fiber_allocate_from_pool(__cilkrts_worker *w);
 CHEETAH_INTERNAL
-void cilk_fiber_deallocate_to_pool(__cilkrts_worker *w,
-                                   struct cilk_fiber *fiber);
+void cilk_fiber_deallocate_to_pool(__cilkrts_worker *w, cilk_fiber *fiber);
 
 #if CILK_ENABLE_ASAN_HOOKS
-void sanitizer_start_switch_fiber(struct cilk_fiber *fiber) __CILKRTS_NOTHROW;
+void sanitizer_start_switch_fiber(cilk_fiber *fiber) __CILKRTS_NOTHROW;
 void sanitizer_finish_switch_fiber(void) __CILKRTS_NOTHROW;
-CHEETAH_INTERNAL void sanitizer_poison_fiber(struct cilk_fiber *fiber);
-CHEETAH_INTERNAL void sanitizer_unpoison_fiber(struct cilk_fiber *fiber);
+CHEETAH_INTERNAL void sanitizer_poison_fiber(cilk_fiber *fiber);
+CHEETAH_INTERNAL void sanitizer_unpoison_fiber(cilk_fiber *fiber);
 #else
-static inline void sanitizer_start_switch_fiber(struct cilk_fiber *fiber) {
-  (void)fiber;
-}
+static inline void
+sanitizer_start_switch_fiber([[maybe_unused]] cilk_fiber *fiber) {}
 static inline void sanitizer_finish_switch_fiber() {}
-static inline void sanitizer_poison_fiber(struct cilk_fiber *fiber) {
-  (void)fiber;
-}
-static inline void sanitizer_unpoison_fiber(struct cilk_fiber *fiber) {
-  (void)fiber;
-}
+static inline void sanitizer_poison_fiber([[maybe_unused]] cilk_fiber *fiber) {}
+static inline void
+sanitizer_unpoison_fiber([[maybe_unused]] cilk_fiber *fiber) {}
 #endif // CILK_ENABLE_ASAN_HOOKS
 #endif

--- a/runtime/frame.h
+++ b/runtime/frame.h
@@ -1,13 +1,14 @@
 #ifndef _CILK_FRAME_H
 #define _CILK_FRAME_H
 
-#include "rts-config.h"
 #include "jmpbuf.h"
+#include "rts-config.h"
 #include <cstddef>
 #include <cstdint>
 
 struct __cilkrts_worker;
 struct __cilkrts_stack_frame;
+struct cilk_fiber;
 
 /**
  * Every spawning function has a frame descriptor.  A spawning function
@@ -28,13 +29,13 @@ struct __cilkrts_stack_frame {
     // This pointer is redundant with the __cilkrts_tls.fh TLS variable, but
     // accessing TLS is expensive on some systems, such as macOS.  It is
     // therefore faster to use this variable when possible.
-    struct cilk_fiber *fh;
+    cilk_fiber *fh;
 
     // call_parent points to the __cilkrts_stack_frame of the closest ancestor
     // spawning function, including spawn helpers, of this frame.  For each
     // worker, these pointers form a singly-linked list ending at the first
     // __cilkrts_stack_frame.
-    struct __cilkrts_stack_frame *call_parent;
+    __cilkrts_stack_frame *call_parent;
 
     // Before every spawn and nontrivial sync the client function
     // saves its continuation here.
@@ -80,15 +81,15 @@ struct __cilkrts_stack_frame {
 
 static const uint32_t frame_magic =
     (((((((((((__CILKRTS_ABI_VERSION * 13) +
-              offsetof(struct __cilkrts_stack_frame, ctx)) *
+              offsetof(__cilkrts_stack_frame, ctx)) *
              13) +
-            offsetof(struct __cilkrts_stack_frame, magic)) *
+            offsetof(__cilkrts_stack_frame, magic)) *
            13) +
-          offsetof(struct __cilkrts_stack_frame, flags)) *
+          offsetof(__cilkrts_stack_frame, flags)) *
          13) +
-        offsetof(struct __cilkrts_stack_frame, call_parent)) *
+        offsetof(__cilkrts_stack_frame, call_parent)) *
        13) +
-      offsetof(struct __cilkrts_stack_frame, extension)));
+      offsetof(__cilkrts_stack_frame, extension)));
 
 #define CHECK_CILK_FRAME_MAGIC(G, F) (frame_magic == (F)->magic)
 
@@ -97,40 +98,40 @@ static const uint32_t frame_magic =
 //===========================================================
 
 /* A frame is set to be stolen as long as it has a corresponding Closure */
-static inline void __cilkrts_set_stolen(struct __cilkrts_stack_frame *sf) {
+static inline void __cilkrts_set_stolen(__cilkrts_stack_frame *sf) {
     sf->flags |= CILK_FRAME_STOLEN;
 }
 
 /* A frame is set to be unsynced only if it has parallel subcomputation
- * underneathe, i.e., only if it has spawned children executing on a different
+ * underneath, i.e., only if it has spawned children executing on a different
  * worker
  */
-static inline void __cilkrts_set_unsynced(struct __cilkrts_stack_frame *sf) {
+static inline void __cilkrts_set_unsynced(__cilkrts_stack_frame *sf) {
     sf->flags |= CILK_FRAME_UNSYNCHED;
 }
 
-static inline void __cilkrts_set_synced(struct __cilkrts_stack_frame *sf) {
+static inline void __cilkrts_set_synced(__cilkrts_stack_frame *sf) {
     sf->flags &= ~CILK_FRAME_UNSYNCHED;
 }
 
 /* Returns nonzero if the frame has been stolen.
    Only used in assertions. */
-static inline int __cilkrts_stolen(struct __cilkrts_stack_frame *sf) {
+static inline int __cilkrts_stolen(__cilkrts_stack_frame *sf) {
     return (sf->flags & CILK_FRAME_STOLEN);
 }
 
 /* Returns nonzero if the frame is synched.  Only used in assertions. */
-static inline int __cilkrts_synced(struct __cilkrts_stack_frame *sf) {
+static inline int __cilkrts_synced(__cilkrts_stack_frame *sf) {
     return ((sf->flags & CILK_FRAME_UNSYNCHED) == 0);
 }
 
 /* Returns nonzero if the frame has never been stolen. */
-static inline int __cilkrts_not_stolen(struct __cilkrts_stack_frame *sf) {
+static inline int __cilkrts_not_stolen(__cilkrts_stack_frame *sf) {
     return ((sf->flags & CILK_FRAME_STOLEN) == 0);
 }
 
 /* Returns nonzero if the frame is throwing an exception. */
-static inline int __cilkrts_throwing(struct __cilkrts_stack_frame *sf) {
+static inline int __cilkrts_throwing(__cilkrts_stack_frame *sf) {
     return (sf->flags & CILK_FRAME_THROWING);
 }
 

--- a/runtime/global.cpp
+++ b/runtime/global.cpp
@@ -1,6 +1,7 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #include "rts-config.h"
+#include <new>
 #endif
 
 #include <pthread.h>
@@ -46,8 +47,7 @@ static void set_alert_debug_level() {
 }
 
 static global_state *global_state_allocate() {
-    cilkrts_alert(BOOT,
-                  "(global_state_init) Allocating global state");
+    cilkrts_alert(BOOT, "(global_state_init) Allocating global state");
     global_state *g = (global_state *)cilk_aligned_alloc(
         __alignof(global_state), sizeof(global_state));
     memset(g, 0, sizeof *g);
@@ -90,7 +90,7 @@ static void set_fiber_pool_cap(global_state *g, unsigned int fiber_pool_cap) {
 }
 
 // not marked as static as it's called by __cilkrts_internal_set_nworkers
-// used by Cilksan to set nworker to 1 
+// used by Cilksan to set nworker to 1
 void set_nworkers(global_state *g, unsigned int nworkers) {
     CILK_ASSERT(!g->workers_started);
     CILK_ASSERT(nworkers <= g->options.nproc);
@@ -145,11 +145,9 @@ static void parse_rts_environment(global_state *g) {
 }
 
 CHEETAH_COLD
-global_state *global_state_init(int argc, char *argv[]) {
+global_state *global_state_init([[maybe_unused]] int argc,
+                                [[maybe_unused]] char *argv[]) {
     cilkrts_alert(BOOT, "(global_state_init) Initializing global state");
-
-    (void)argc; // not currently used
-    (void)argv; // not currently used
 
 #ifdef DEBUG
     setlinebuf(stderr);
@@ -158,7 +156,7 @@ global_state *global_state_init(int argc, char *argv[]) {
     set_alert_debug_level(); // alert / debug used by global_state_allocate
     global_state *g = global_state_allocate();
 
-    g->options = (struct rts_options)DEFAULT_OPTIONS;
+    g->options = (rts_options)DEFAULT_OPTIONS;
     parse_rts_environment(g);
 
     unsigned active_size = g->options.nproc;
@@ -174,15 +172,13 @@ global_state *global_state_init(int argc, char *argv[]) {
 
     g->terminate = false;
 
-    g->worker_args =
-        (struct worker_args *)calloc(active_size, sizeof(struct worker_args));
-    g->workers =
-        (__cilkrts_worker **)calloc(active_size, sizeof(__cilkrts_worker *));
-    g->busy = (BusyClosure *)cilk_aligned_alloc(
-        __alignof__(BusyClosure), active_size * sizeof(BusyClosure));
+    g->worker_args = new worker_args[active_size];
+    g->workers = new __cilkrts_worker *[active_size]();
+    g->busy =
+        new (std::align_val_t(alignof(BusyClosure))) BusyClosure[active_size];
     g->threads = new std::thread[active_size];
-    g->index_to_worker = (worker_id *)calloc(active_size, sizeof(worker_id));
-    g->worker_to_index = (worker_id *)calloc(active_size, sizeof(worker_id));
+    g->index_to_worker = new worker_id[active_size]();
+    g->worker_to_index = new worker_id[active_size]();
     cilk_internal_malloc_global_init(g); // initialize internal malloc first
     cilk_fiber_pool_global_init(g);
     cilk_global_sched_stats_init(&(g->stats));
@@ -205,17 +201,16 @@ void for_each_worker_rev(global_state *g,
             fn(g->workers[i], data);
 }
 
-void global_state::record_event(scheduler_event::event code,
-                                int data, worker_id self) {
+void global_state::record_event(scheduler_event::event code, int data,
+                                worker_id self) {
 #ifdef __amd64__ // really, if __builtin_readcyclecounter is fast
-    struct scheduler_event *event = &events[event_index++ % 1024];
+    scheduler_event *event = &events[event_index++ % 1024];
     event->time = __builtin_readcyclecounter();
     event->code = code;
     event->data1 = data;
     event->worker = self;
 #endif
 }
-
 
 // Routines to update global flags to prevent workers from re-entering the
 // work-stealing loop.  Note that we don't wait for the workers to exit the
@@ -308,9 +303,10 @@ uint32_t global_state::thief_disengage(worker_id self) {
         // designed to handle cases where multiple threads waiting on the futex
         // were woken up and where there may be spurious wakeups.
         while (uint32_t val =
-               disengaged_thieves.load(std::memory_order_relaxed)) {
-            if (disengaged_thieves.compare_exchange_weak(val, val - 1,
-                    std::memory_order_release, std::memory_order_relaxed)) {
+                   disengaged_thieves.load(std::memory_order_relaxed)) {
+            if (disengaged_thieves.compare_exchange_weak(
+                    val, val - 1, std::memory_order_release,
+                    std::memory_order_relaxed)) {
                 return val;
             }
             busy_loop_pause();
@@ -333,17 +329,15 @@ void global_state::wake_thieves() {
 // already, update the global state to indicate that this worker is engaged in
 // work stealing.
 bool global_state::thief_should_wait() {
-    while (uint32_t val =
-           disengaged_thieves.load(std::memory_order_relaxed)) {
-        if (disengaged_thieves.compare_exchange_weak(
-                val, val - 1, std::memory_order_release,
-                std::memory_order_relaxed))
+    while (uint32_t val = disengaged_thieves.load(std::memory_order_relaxed)) {
+        if (disengaged_thieves.compare_exchange_weak(val, val - 1,
+                                                     std::memory_order_release,
+                                                     std::memory_order_relaxed))
             return false;
         busy_loop_pause();
     }
     return true;
 }
-
 
 //=========================================================
 // Operations to disengage and reengage workers within the work-stealing loop.
@@ -382,7 +376,6 @@ void global_state::swap_worker_with_target(worker_id self,
     worker_to_index[target_worker] = self_index;
     worker_to_index[self] = target_index;
 }
-
 
 void global_state::disengage_worker(unsigned int nworkers, worker_id self) {
     cilk_mutex_lock(&index_lock);

--- a/runtime/global.h
+++ b/runtime/global.h
@@ -32,15 +32,16 @@ struct BusyClosure;
 // clang-format on
 
 struct rts_options {
-    size_t stacksize;            /* can be set via env variable CILK_STACKSIZE */
-    unsigned int nproc;          /* can be set via env variable CILK_NWORKERS */
-    unsigned int deqdepth;       /* can be set via env variable CILK_DEQDEPTH */
-    unsigned int fiber_pool_cap; /* can be set via env variable CILK_FIBER_POOL */
+    size_t stacksize;      /* can be set via env variable CILK_STACKSIZE */
+    unsigned int nproc;    /* can be set via env variable CILK_NWORKERS */
+    unsigned int deqdepth; /* can be set via env variable CILK_DEQDEPTH */
+    unsigned int
+        fiber_pool_cap; /* can be set via env variable CILK_FIBER_POOL */
 };
 
 struct worker_args {
-    worker_id id;
-    global_state *g;
+    worker_id id = 0;
+    global_state *g = nullptr;
 };
 
 struct scheduler_event {
@@ -60,38 +61,38 @@ struct scheduler_event {
 
 struct CHEETAH_INTERNAL global_state {
     /* globally-visible options (read-only after init) */
-    struct rts_options options;
+    rts_options options;
 
     unsigned int nworkers; /* size of next 4 arrays */
-    struct worker_args *worker_args;
-    struct __cilkrts_worker **workers;
+    worker_args *worker_args;
+    __cilkrts_worker **workers;
     /* dynamically-allocated array of busy closures, one per processor */
     BusyClosure *busy;
     std::thread *threads;
-    struct Closure *root_closure;
+    Closure *root_closure;
 
-    struct cilk_fiber_pool fiber_pool __attribute__((aligned(CILK_CACHE_LINE)));
-    struct global_im_pool im_pool __attribute__((aligned(CILK_CACHE_LINE)));
-    struct cilk_im_desc im_desc __attribute__((aligned(CILK_CACHE_LINE)));
+    alignas(CILK_CACHE_LINE) cilk_fiber_pool fiber_pool;
+    alignas(CILK_CACHE_LINE) global_im_pool im_pool;
+    alignas(CILK_CACHE_LINE) cilk_im_desc im_desc;
     cilk_mutex im_lock; // lock for accessing global im_desc
 
     // These fields are accessed exclusively by the boss thread.
 
-    jmpbuf boss_ctx __attribute__((aligned(CILK_CACHE_LINE)));
+    alignas(CILK_CACHE_LINE) jmpbuf boss_ctx;
     void *orig_rsp;
     bool workers_started;
 
     // This field is shared between the boss thread and a couple workers.
 
-    std::atomic<bool> cilkified __attribute__((aligned(CILK_CACHE_LINE)));
+    alignas(CILK_CACHE_LINE) std::atomic<bool> cilkified;
 
     // These fields are shared among all workers in the work-stealing loop.
 
-    std::atomic<bool> done __attribute__((aligned(CILK_CACHE_LINE)));
+    alignas(CILK_CACHE_LINE) std::atomic<bool> done;
     bool terminate;
     bool root_closure_initialized;
 
-    worker_id *index_to_worker __attribute__((aligned(CILK_CACHE_LINE)));
+    alignas(CILK_CACHE_LINE) worker_id *index_to_worker;
     worker_id *worker_to_index;
     cilk_mutex index_lock;
 
@@ -99,12 +100,12 @@ struct CHEETAH_INTERNAL global_state {
     // the disengaged workers.  Lower 32 bits count the sentinel workers.  These
     // two counts are stored in a single word to make it easier to update both
     // counts atomically.
-    std::atomic<uint64_t> disengaged_sentinel __attribute__((aligned(CILK_CACHE_LINE)));
+    alignas(CILK_CACHE_LINE) std::atomic<uint64_t> disengaged_sentinel;
 #define GET_DISENGAGED(D) ((D) >> 32)
 #define GET_SENTINEL(D) ((D) & 0xffffffff)
 #define DISENGAGED_SENTINEL(A, B) (((uint64_t)(A) << 32) | (uint32_t)(B))
 
-    std::atomic<uint32_t> disengaged_thieves __attribute__((aligned(CILK_CACHE_LINE)));
+    alignas(CILK_CACHE_LINE) std::atomic<uint32_t> disengaged_thieves;
 
     cilk_mutex print_lock; // global lock for printing messages
 
@@ -114,15 +115,15 @@ struct CHEETAH_INTERNAL global_state {
     // does not need to check whether it's reading an uninitialized entry in the
     // global workers array.  Instead, this dummy worker will ensure the fast
     // check in Closure_steal always fails.
-    struct __cilkrts_worker dummy_worker;
+    __cilkrts_worker dummy_worker;
 
-    struct global_sched_stats stats;
+    global_sched_stats stats;
 
     uint64_t start_time;
 
-    _Atomic size_t event_index;
+    std::atomic<size_t> event_index;
 
-    struct scheduler_event events[1024];
+    scheduler_event events[1024];
 
     CHEETAH_INTERNAL void set_cilkified();
     CHEETAH_INTERNAL void signal_uncilkified();
@@ -165,36 +166,34 @@ struct CHEETAH_INTERNAL global_state {
                                         unsigned int *const sample_threshold);
     void reset_fails(unsigned int fails);
 #endif
-    unsigned int maybe_reengage_workers(worker_id self,
-                       unsigned int nworkers, __cilkrts_worker *const w,
-                       unsigned int fails,
-                       unsigned int *const sample_threshold,
-                       history_sample_t *const inefficient_history,
-                       history_sample_t *const efficient_history,
-                       unsigned int *const sentinel_count_history,
-                       unsigned int *const sentinel_count_history_tail,
-                       unsigned int *const recent_sentinel_count);
-    unsigned int go_to_sleep_maybe(worker_id self,
-                                   unsigned int nworkers,
-                                   const unsigned int NAP_THRESHOLD,
-                                   __cilkrts_worker *const w,
-                                   Closure *const t, unsigned int fails,
-                                   unsigned int *const sample_threshold,
-                                   history_sample_t *const inefficient_history,
-                                   history_sample_t *const efficient_history,
-                                   unsigned int *const sentinel_count_history,
-                                   unsigned int *const sentinel_count_history_tail,
-                                   unsigned int *const recent_sentinel_count);
-    unsigned int handle_failed_steal_attempts(worker_id self,
-                             unsigned int nworkers, const unsigned int NAP_THRESHOLD,
-                             __cilkrts_worker *const w,
-                             unsigned int fails,
-                             unsigned int *const sample_threshold,
-                             history_sample_t *const inefficient_history,
-                             history_sample_t *const efficient_history,
-                             unsigned int *const sentinel_count_history,
-                             unsigned int *const sentinel_count_history_tail,
-                             unsigned int *const recent_sentinel_count);
+    unsigned int
+    maybe_reengage_workers(worker_id self, unsigned int nworkers,
+                           __cilkrts_worker *const w, unsigned int fails,
+                           unsigned int *const sample_threshold,
+                           history_sample_t *const inefficient_history,
+                           history_sample_t *const efficient_history,
+                           unsigned int *const sentinel_count_history,
+                           unsigned int *const sentinel_count_history_tail,
+                           unsigned int *const recent_sentinel_count);
+    unsigned int
+    go_to_sleep_maybe(worker_id self, unsigned int nworkers,
+                      const unsigned int NAP_THRESHOLD,
+                      __cilkrts_worker *const w, Closure *const t,
+                      unsigned int fails, unsigned int *const sample_threshold,
+                      history_sample_t *const inefficient_history,
+                      history_sample_t *const efficient_history,
+                      unsigned int *const sentinel_count_history,
+                      unsigned int *const sentinel_count_history_tail,
+                      unsigned int *const recent_sentinel_count);
+    unsigned int handle_failed_steal_attempts(
+        worker_id self, unsigned int nworkers, const unsigned int NAP_THRESHOLD,
+        __cilkrts_worker *const w, unsigned int fails,
+        unsigned int *const sample_threshold,
+        history_sample_t *const inefficient_history,
+        history_sample_t *const efficient_history,
+        unsigned int *const sentinel_count_history,
+        unsigned int *const sentinel_count_history_tail,
+        unsigned int *const recent_sentinel_count);
 
     unsigned int init_fails(uint32_t wake_val);
 };

--- a/runtime/hyperobject_base.h
+++ b/runtime/hyperobject_base.h
@@ -1,6 +1,7 @@
 #ifndef _HYPEROBJECT_BASE
 #define _HYPEROBJECT_BASE
 
+#include "cilk/cilk_api.h"
 #include <cilk/reducer> // __cilk_reduce_fn
 #include <variant>
 
@@ -21,11 +22,11 @@
 //   reducer_data is storing a pointer to the view or the view itself.
 
 struct reducer_data {
-    void *view;
+    void *view = nullptr;
     std::variant<
         __reducer_base *,
         const __cilk_reduce_fn *,
-        void (*)(void *, void *)
+        __cilk_c_reduce_fn *
         > extra;
 };
 

--- a/runtime/init.cpp
+++ b/runtime/init.cpp
@@ -33,8 +33,7 @@ typedef cpuset_t cpu_set_t;
 extern local_state default_worker_local_state;
 
 static local_state *worker_local_init(local_state *l, global_state *g) {
-    l->shadow_stack = (__cilkrts_stack_frame **)calloc(
-        g->options.deqdepth, sizeof(struct __cilkrts_stack_frame *));
+    l->shadow_stack = new __cilkrts_stack_frame *[g->options.deqdepth]();
     for (int i = 0; i < JMPBUF_SIZE; i++) {
         l->rts_ctx[i] = nullptr;
     }
@@ -51,9 +50,8 @@ static local_state *worker_local_init(local_state *l, global_state *g) {
     return l;
 }
 
-static void worker_local_destroy(local_state *l, global_state *g) {
-    (void)l; // not currently used
-    (void)g; // not currently used
+static void worker_local_destroy([[maybe_unused]] local_state *l,
+                                 [[maybe_unused]] global_state *g) {
     /* currently nothing to do here */
 }
 
@@ -154,7 +152,7 @@ static void move_bit(int cpu, cpu_set_t *to, cpu_set_t *from) {
  * for different workers.
  *
  * @param worker_mask     (output) the processor mask that will store the set
- *                        of all cpu ids to assigne to worker <code>w_id<\code>
+ *                        of all cpu ids to assigned to worker <code>w_id<\code>
  * @param w_id            the id of the worker that will be pinned using the
  *                        <code>worker_mask<\code> (used for debug messages)
  * @param cpu_start       the cpu id from which to start searching in the
@@ -204,8 +202,8 @@ static inline int fill_worker_mask_and_get_next_cpu(
  */
 static inline void pin_thread(std::thread &thread_handle,
                               cpu_set_t *const worker_mask) {
-    int const err =
-        pthread_setaffinity_np(thread_handle.native_handle(), sizeof(*worker_mask), worker_mask);
+    int const err = pthread_setaffinity_np(thread_handle.native_handle(),
+                                           sizeof(*worker_mask), worker_mask);
     CILK_ASSERT_G(err == 0);
 }
 #endif
@@ -221,7 +219,7 @@ static inline void pin_thread(std::thread &thread_handle,
  * @return     the result of <code>scheduler_thread_proc<\code>
  */
 void *init_threads_and_enter_scheduler(worker_args *w_arg) {
-    struct global_state *g = w_arg->g;
+    global_state *g = w_arg->g;
 
     int const worker_start = 2;
 
@@ -319,8 +317,7 @@ void *init_threads_and_enter_scheduler(worker_args *w_arg) {
 #endif // ENABLE_WORKER_PINNING
 
     for (int w = worker_start; w < n_threads; w++) {
-        g->threads[w] = std::thread{scheduler_thread_proc,
-                                         &g->worker_args[w]};
+        g->threads[w] = std::thread{scheduler_thread_proc, &g->worker_args[w]};
 
 #if ENABLE_WORKER_PINNING
 #ifdef CPU_SETSIZE
@@ -352,10 +349,8 @@ static void threads_init(global_state *g) {
 
     // Make sure we are supposed to create worker threads
     if (worker_start < (int)g->nworkers) {
-        g->threads[worker_start] = std::thread{
-                                          init_threads_and_enter_scheduler,
-                                            &g->worker_args[worker_start]
-          };
+        g->threads[worker_start] = std::thread{init_threads_and_enter_scheduler,
+                                               &g->worker_args[worker_start]};
     }
 }
 
@@ -369,7 +364,7 @@ global_state *__cilkrts_startup(int argc, char *argv[]) {
     // allocate the closure and fiber.
     __cilkrts_worker *w0 = g->workers[0];
     Closure *t = Closure::create(w0, nullptr);
-    struct cilk_fiber *fiber = cilk_fiber_allocate(g->options.stacksize);
+    cilk_fiber *fiber = cilk_fiber_allocate(g->options.stacksize);
     t->fiber = fiber;
     g->root_closure = t;
 
@@ -377,8 +372,7 @@ global_state *__cilkrts_startup(int argc, char *argv[]) {
 }
 
 // Global constructor for starting up the default cilkrts.
-__attribute__((constructor))
-static void __default_cilkrts_startup() {
+__attribute__((constructor)) static void __default_cilkrts_startup() {
     default_cilkrts = __cilkrts_startup(0, nullptr);
 
     for (unsigned i = 0; i < cilkrts_callbacks.last_init; ++i)
@@ -457,7 +451,7 @@ static inline __attribute__((noinline)) void boss_wait_helper(void) {
 // Setup runtime structures to start a new Cilkified region.  Executed by the
 // Cilkifying thread in cilkify().
 void __cilkrts_internal_invoke_cilkified_root(__cilkrts_stack_frame *sf)
-  __CILKRTS_NOTHROW {
+    __CILKRTS_NOTHROW {
     global_state *g = default_cilkrts;
 
     // Initialize the boss thread's runtime structures, if necessary.
@@ -497,9 +491,8 @@ void __cilkrts_internal_invoke_cilkified_root(__cilkrts_stack_frame *sf)
 
     // Setup the stack pointer to point at the root closure's fiber.
     g->orig_rsp = SP(sf);
-    void *new_rsp =
+    [[maybe_unused]] void *new_rsp =
         (void *)sysdep_reset_stack_for_resume(root_closure->fiber, sf);
-    USE_UNUSED(new_rsp);
     CILK_ASSERT_POINTER_EQUAL(SP(sf), new_rsp);
 
     // Mark that this root frame is last (meaning, at the top of the stack)
@@ -620,17 +613,17 @@ void __cilkrts_internal_exit_cilkified_root(global_state *g,
 
 static const char *event_code(scheduler_event::event code) {
     switch (code) {
-    case scheduler_event:: CILKIFY:
+    case scheduler_event::CILKIFY:
         return "cilkify";
-    case scheduler_event:: UNCILKIFY:
+    case scheduler_event::UNCILKIFY:
         return "uncilkify";
-    case scheduler_event:: WAIT_CILKIFIED:
+    case scheduler_event::WAIT_CILKIFIED:
         return "wait_cilkified";
-    case scheduler_event:: WAIT_DISENGAGED:
+    case scheduler_event::WAIT_DISENGAGED:
         return "wait_disengaged";
-    case scheduler_event:: MORE_THIEVES:
+    case scheduler_event::MORE_THIEVES:
         return "more_thieves";
-    case scheduler_event:: ALL_THIEVES:
+    case scheduler_event::ALL_THIEVES:
         return "all_thieves";
     default:
         return "?";
@@ -653,11 +646,11 @@ static void print_events(global_state *g) {
         unsigned long us = (unsigned long)(t / 1000);
         unsigned int ns = (unsigned int)(t % 1000);
         if (w == NO_WORKER)
-            printf("%11lu.%03u %20s --- %d\n", us, ns,
-                   code_s, g->events[i].data1);
+            printf("%11lu.%03u %20s --- %d\n", us, ns, code_s,
+                   g->events[i].data1);
         else
-            printf("%11lu.%03u %20s %3u %d\n", us, ns,
-                   code_s, (unsigned int)w, g->events[i].data1);
+            printf("%11lu.%03u %20s %3u %d\n", us, ns, code_s, (unsigned int)w,
+                   g->events[i].data1);
     }
 }
 
@@ -677,18 +670,18 @@ static void global_state_deinit(global_state *g) {
     cilk_mutex_destroy(&(g->index_lock));
     /* pthread_mutex_destroy(&g->start_thieves_lock); */
     /* pthread_cond_destroy(&g->start_thieves_cond_var); */
-    free(g->worker_args);
+    delete[] g->worker_args;
     g->worker_args = nullptr;
-    free(g->workers);
+    delete[] g->workers;
     g->workers = nullptr;
     g->nworkers = 0;
-    free(g->busy);
+    delete[] g->busy;
     g->busy = nullptr;
-    delete [] g->threads;
+    delete[] g->threads;
     g->threads = nullptr;
-    free(g->index_to_worker);
+    delete[] g->index_to_worker;
     g->index_to_worker = nullptr;
-    free(g->worker_to_index);
+    delete[] g->worker_to_index;
     g->worker_to_index = nullptr;
     free(g);
 }
@@ -700,9 +693,7 @@ static void busy_deinit(global_state *g) {
     }
 }
 
-static void worker_terminate(__cilkrts_worker *w, void *data) {
-    (void)data; // not currently used
-
+static void worker_terminate(__cilkrts_worker *w, [[maybe_unused]] void *data) {
     cilk_fiber_pool_per_worker_terminate(w);
     hyper_table *ht = w->hyper_table;
     if (ht) {
@@ -750,9 +741,9 @@ static void workers_deinit(global_state *g) {
         if (!worker_is_valid(w, g))
             continue;
         cilk_internal_malloc_per_worker_destroy(w); // internal malloc last
-        free(w->l->shadow_stack);
+        delete[] w->l->shadow_stack;
         w->l->shadow_stack = nullptr;
-        *(struct local_state **)(&w->l) = nullptr;
+        *(local_state **)(&w->l) = nullptr;
         if (i != 0)
             free(w);
     }
@@ -760,8 +751,7 @@ static void workers_deinit(global_state *g) {
     /* TODO: Export initial reducer map */
 }
 
-CHEETAH_INTERNAL CHEETAH_COLD
-void __cilkrts_shutdown(global_state *g) {
+CHEETAH_INTERNAL CHEETAH_COLD void __cilkrts_shutdown(global_state *g) {
     CILK_ASSERT(exception_reducer_is_empty());
     // If the workers are still running, stop them now.
     if (g->workers_started)
@@ -795,7 +785,6 @@ void __cilkrts_shutdown(global_state *g) {
 }
 
 // Global destructor for shutting down the default cilkrts
-__attribute__((destructor))
-static void __default_cilkrts_shutdown() {
+__attribute__((destructor)) static void __default_cilkrts_shutdown() {
     __cilkrts_shutdown(default_cilkrts);
 }

--- a/runtime/internal-malloc-impl.h
+++ b/runtime/internal-malloc-impl.h
@@ -33,7 +33,7 @@ struct im_bucket {
 
 /* One of these per worker, and one global */
 struct cilk_im_desc {
-    struct im_bucket buckets[NUM_BUCKETS];
+    im_bucket buckets[NUM_BUCKETS];
     long used; // local alloc - local free, may be negative
     long num_malloc[IM_NUM_TAGS];
 };

--- a/runtime/internal-malloc.cpp
+++ b/runtime/internal-malloc.cpp
@@ -58,25 +58,25 @@ static inline unsigned int bucket_to_size(int which_bucket) {
     return bucket_sizes[which_bucket];
 }
 
-static void add_to_free_list(struct im_bucket *bucket, void *p) {
-    ((struct free_block *)p)->next = bucket->free_list;
+static void add_to_free_list(im_bucket *bucket, void *p) {
+    ((free_block *)p)->next = bucket->free_list;
     bucket->free_list = p;
     ++bucket->free_list_size;
 }
 
-static void *remove_from_free_list(struct im_bucket *bucket) {
+static void *remove_from_free_list(im_bucket *bucket) {
     void *mem = bucket->free_list;
     if (mem) {
-        bucket->free_list = ((struct free_block *)mem)->next;
+        bucket->free_list = ((free_block *)mem)->next;
         --bucket->free_list_size;
     }
     return mem;
 }
 
-/* initialize the buckets in struct cilk_im_desc */
-static void init_im_buckets(struct cilk_im_desc *im_desc) {
+/* initialize the buckets in cilk_im_desc */
+static void init_im_buckets(cilk_im_desc *im_desc) {
     for (int i = 0; i < NUM_BUCKETS; i++) {
-        struct im_bucket *bucket = &(im_desc->buckets[i]);
+        im_bucket *bucket = &(im_desc->buckets[i]);
         bucket->free_list = nullptr;
         bucket->free_list_size = 0;
         bucket->free_list_limit = bucket_capacity[i];
@@ -93,10 +93,10 @@ static void init_im_buckets(struct cilk_im_desc *im_desc) {
 // Private helper functions for debugging
 //=========================================================
 
-static void dump_buckets(FILE *out, struct cilk_im_desc *d) {
+static void dump_buckets(FILE *out, cilk_im_desc *d) {
     fprintf(out, "  %zd bytes used\n", d->used);
     for (unsigned i = 0; i < NUM_BUCKETS; ++i) {
-        struct im_bucket *b = &d->buckets[i];
+        im_bucket *b = &d->buckets[i];
         if (!b->free_list && !b->free_list_size && !b->allocated)
             continue;
         fprintf(out, "  [%u] %d allocated (%d max, %zd wasted), %u free\n",
@@ -105,14 +105,14 @@ static void dump_buckets(FILE *out, struct cilk_im_desc *d) {
     }
 }
 
-static size_t free_bytes(struct cilk_im_desc *desc) {
+static size_t free_bytes(cilk_im_desc *desc) {
     size_t free = 0;
     for (unsigned i = 0; i < NUM_BUCKETS; ++i)
         free += (size_t)desc->buckets[i].free_list_size * bucket_sizes[i];
     return free;
 }
 
-static long wasted_bytes(struct cilk_im_desc *desc) {
+static long wasted_bytes(cilk_im_desc *desc) {
     long wasted = 0;
     for (unsigned i = 0; i < NUM_BUCKETS; ++i)
         wasted += desc->buckets[i].wasted;
@@ -166,7 +166,7 @@ void internal_malloc_global_check(global_state *g) {
        global used = worker used + free
        global used + global free = allocated. */
 
-    struct cilk_im_desc *d = &(g->im_desc);
+    cilk_im_desc *d = &(g->im_desc);
 
     size_t total_malloc[IM_NUM_TAGS];
     for (int i = 0; i < IM_NUM_TAGS; ++i)
@@ -202,13 +202,13 @@ void internal_malloc_global_check(global_state *g) {
                worker_total);
 }
 
-static void assert_global_pool(struct global_im_pool *pool) {
+static void assert_global_pool(global_im_pool *pool) {
     CILK_ASSERT(pool->mem_list_index < pool->mem_list_size);
     if (pool->wasted > 0)
         CILK_ASSERT(pool->wasted < pool->allocated);
 }
 
-static void assert_bucket(struct im_bucket *bucket) {
+static void assert_bucket(im_bucket *bucket) {
     CILK_ASSERT(!!bucket->free_list == !!bucket->free_list_size);
     CILK_ASSERT_LE(bucket->free_list_size, bucket->free_list_limit, "%u");
     CILK_ASSERT_LE(bucket->allocated, bucket->max_allocated, "%d");
@@ -244,7 +244,7 @@ static void print_worker_buckets_hwm(__cilkrts_worker *w, void *data) {
     fprintf(fp, "\n");
 }
 
-static void print_im_buckets_stats(struct global_state *g) {
+static void print_im_buckets_stats(global_state *g) {
     fprintf(stderr, "\nBYTES IN FREE LISTS:\n");
     fprintf(stderr, HDR_DESC, "Bucket size:");
     for (int j = 0; j < NUM_BUCKETS; j++) {
@@ -273,7 +273,7 @@ static void print_im_buckets_stats(struct global_state *g) {
     fprintf(stderr, "\n");
 }
 
-static void print_internal_malloc_stats(struct global_state *g) {
+static void print_internal_malloc_stats(global_state *g) {
     unsigned page_size = 1U << cheetah_page_shift;
     fprintf(stderr, "\nINTERNAL MALLOC STATS\n");
     fprintf(stderr,
@@ -317,7 +317,7 @@ static void free_to_system(void *p, size_t size) {
  */
 static void extend_global_pool(__cilkrts_worker *w) {
 
-    struct global_im_pool *im_pool = &(w->g->im_pool);
+    global_im_pool *im_pool = &(w->g->im_pool);
     im_pool->mem_begin = malloc_from_system(w, INTERNAL_MALLOC_CHUNK_SIZE);
     im_pool->mem_end = im_pool->mem_begin + INTERNAL_MALLOC_CHUNK_SIZE;
     im_pool->allocated += INTERNAL_MALLOC_CHUNK_SIZE;
@@ -353,14 +353,14 @@ static void *global_im_alloc(__cilkrts_worker *w, size_t size,
     CILK_ASSERT(size <= SIZE_THRESH);
     CILK_ASSERT(which_bucket < NUM_BUCKETS);
 
-    struct im_bucket *bucket = &(g->im_desc.buckets[which_bucket]);
-    struct cilk_im_desc *im_desc = &(g->im_desc);
+    im_bucket *bucket = &(g->im_desc.buckets[which_bucket]);
+    cilk_im_desc *im_desc = &(g->im_desc);
     im_desc->used += size;
     /* ??? count calls to this function? */
 
     void *mem = remove_from_free_list(bucket);
     if (!mem) {
-        struct global_im_pool *im_pool = &(g->im_pool);
+        global_im_pool *im_pool = &(g->im_pool);
         // allocate from the global pool
         if ((im_pool->mem_begin + size) > im_pool->mem_end) {
             // consider the left over as waste for now
@@ -375,7 +375,7 @@ static void *global_im_alloc(__cilkrts_worker *w, size_t size,
     return mem;
 }
 
-static void global_im_pool_destroy(struct global_im_pool *im_pool) {
+static void global_im_pool_destroy(global_im_pool *im_pool) {
 
     for (unsigned i = 0; i < im_pool->mem_list_size; i++) {
         void *mem = im_pool->mem_list[i];
@@ -441,7 +441,7 @@ static void im_allocate_batch(__cilkrts_worker *w, size_t size,
                               unsigned int bucket_index) {
     global_state *g = w->g;
     local_state *l = w->l;
-    struct im_bucket *bucket = &l->im_desc.buckets[bucket_index];
+    im_bucket *bucket = &l->im_desc.buckets[bucket_index];
     unsigned int batch_size = bucket_capacity[bucket_index] / 2;
     cilk_mutex_lock(&(g->im_lock));
     for (unsigned int i = 0; i < batch_size; i++) {
@@ -464,7 +464,7 @@ static void im_free_batch(__cilkrts_worker *w, size_t size,
     global_state *g = w->g;
     local_state *l = w->l;
     unsigned int batch_size = bucket_capacity[which_bucket] / 2;
-    struct im_bucket *bucket = &(l->im_desc.buckets[which_bucket]);
+    im_bucket *bucket = &(l->im_desc.buckets[which_bucket]);
     cilk_mutex_lock(&(g->im_lock));
     for (unsigned int i = 0; i < batch_size; ++i) {
         void *mem = remove_from_free_list(bucket);
@@ -483,7 +483,7 @@ static void im_free_batch(__cilkrts_worker *w, size_t size,
  * last-in-first-out
  */
 CHEETAH_INTERNAL
-void *cilk_internal_malloc(__cilkrts_worker *w, size_t size, enum im_tag tag) {
+void *cilk_internal_malloc(__cilkrts_worker *w, size_t size, im_tag tag) {
     local_state *l = w->l;
     unsigned int which_bucket = size_to_bucket(size);
     if (which_bucket >= NUM_BUCKETS) {
@@ -496,7 +496,7 @@ void *cilk_internal_malloc(__cilkrts_worker *w, size_t size, enum im_tag tag) {
     l->im_desc.num_malloc[tag] += 1;
 
     unsigned int csize = bucket_to_size(which_bucket); // canonicalize the size
-    struct im_bucket *bucket = &(l->im_desc.buckets[which_bucket]);
+    im_bucket *bucket = &(l->im_desc.buckets[which_bucket]);
     bucket->wasted += csize - size;
     void *mem = remove_from_free_list(bucket);
 
@@ -517,8 +517,7 @@ void *cilk_internal_malloc(__cilkrts_worker *w, size_t size, enum im_tag tag) {
 /*
  * Free simply returns to the free list; last-in-first-out
  */
-void cilk_internal_free(__cilkrts_worker *w, void *p, size_t size,
-                        enum im_tag tag) {
+void cilk_internal_free(__cilkrts_worker *w, void *p, size_t size, im_tag tag) {
     if (size > SIZE_THRESH) {
         free_to_system(p, size);
         return;
@@ -533,7 +532,7 @@ void cilk_internal_free(__cilkrts_worker *w, void *p, size_t size,
     unsigned int which_bucket = size_to_bucket(size);
     CILK_ASSERT(which_bucket >= 0 && which_bucket < NUM_BUCKETS);
     unsigned int csize = bucket_to_size(which_bucket); // canonicalize the size
-    struct im_bucket *bucket = &(l->im_desc.buckets[which_bucket]);
+    im_bucket *bucket = &(l->im_desc.buckets[which_bucket]);
     bucket->wasted -= csize - size;
 
     add_to_free_list(bucket, p);
@@ -552,7 +551,7 @@ void cilk_internal_free(__cilkrts_worker *w, void *p, size_t size,
 /* This function is called after workers have terminated.
    It has no locking. */
 void cilk_internal_free_global(global_state *g, void *p, size_t size,
-                               enum im_tag tag) {
+                               im_tag tag) {
     unsigned int which_bucket = size_to_bucket(size);
     add_to_free_list(&g->im_desc.buckets[which_bucket], p);
     g->im_desc.num_malloc[tag]--;
@@ -589,8 +588,7 @@ void cilk_internal_malloc_per_worker_destroy(__cilkrts_worker *w) {
     /* The main closure and fiber have not yet been destroyed.  They are
        allocated with system malloc instead of internal malloc. */
 #if CILK_DEBUG
-    local_state *l = w->l;
-    (void)l;
+    [[maybe_unused]] local_state *l = w->l;
     for (unsigned int i = 0; i < NUM_BUCKETS; i++) {
         CILK_ASSERT_INDEX_ZERO(l->im_desc.buckets, i, .free_list_size, "%u");
         CILK_ASSERT_INDEX_ZERO(l->im_desc.buckets, i, .free_list, "%p");
@@ -599,7 +597,7 @@ void cilk_internal_malloc_per_worker_destroy(__cilkrts_worker *w) {
 #endif
 }
 
-const char *name_for_im_tag(enum im_tag tag) {
+const char *name_for_im_tag(im_tag tag) {
     switch (tag) {
     case IM_UNCLASSIFIED:
         return "unclassified";

--- a/runtime/internal-malloc.h
+++ b/runtime/internal-malloc.h
@@ -4,7 +4,8 @@
 #include "rts-config.h"
 #include <cstdlib>
 
-typedef struct __cilkrts_worker __cilkrts_worker;
+struct __cilkrts_worker;
+struct global_state;
 
 CHEETAH_INTERNAL extern int cheetah_page_shift;
 
@@ -39,24 +40,22 @@ static inline void *cilk_aligned_alloc(size_t alignment, size_t size) {
 }
 
 // public functions (external to source file, internal to library)
-CHEETAH_INTERNAL void cilk_internal_malloc_global_init(struct global_state *g);
+CHEETAH_INTERNAL void cilk_internal_malloc_global_init(global_state *g);
 CHEETAH_INTERNAL void internal_malloc_global_check(global_state *g);
-CHEETAH_INTERNAL void
-cilk_internal_malloc_global_terminate(struct global_state *g);
-CHEETAH_INTERNAL void
-cilk_internal_malloc_global_destroy(struct global_state *g);
+CHEETAH_INTERNAL void cilk_internal_malloc_global_terminate(global_state *g);
+CHEETAH_INTERNAL void cilk_internal_malloc_global_destroy(global_state *g);
 CHEETAH_INTERNAL void cilk_internal_malloc_per_worker_init(__cilkrts_worker *w);
 CHEETAH_INTERNAL void
 cilk_internal_malloc_per_worker_destroy(__cilkrts_worker *w);
 CHEETAH_INTERNAL void
 cilk_internal_malloc_per_worker_terminate(__cilkrts_worker *w);
-__attribute__((alloc_size(2), assume_aligned(32), malloc))
-CHEETAH_INTERNAL void *
-cilk_internal_malloc(__cilkrts_worker *w, size_t size, enum im_tag tag);
+__attribute__((alloc_size(2), assume_aligned(32),
+               malloc)) CHEETAH_INTERNAL void *
+cilk_internal_malloc(__cilkrts_worker *w, size_t size, im_tag tag);
 CHEETAH_INTERNAL void cilk_internal_free(__cilkrts_worker *w, void *p,
-                                         size_t size, enum im_tag tag);
+                                         size_t size, im_tag tag);
 /* Release memory to the global pool after workers have stopped. */
-CHEETAH_INTERNAL void cilk_internal_free_global(struct global_state *, void *p,
-                                                size_t size, enum im_tag tag);
+CHEETAH_INTERNAL void cilk_internal_free_global(global_state *, void *p,
+                                                size_t size, im_tag tag);
 
 #endif // _INTERAL_MALLOC_H

--- a/runtime/local-hypertable.cpp
+++ b/runtime/local-hypertable.cpp
@@ -1,10 +1,8 @@
-#include "internal-malloc.h" /* only needed for new view allocation */
 #include "local-hypertable.h"
-
+#include "cilk/cilk_api.h"
 #include "cilk/reducer"
-
 #include "debug.h"
-
+#include "internal-malloc.h" /* only needed for new view allocation */
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
@@ -16,8 +14,8 @@ static void make_tombstone(uintptr_t *key) { *key = KEY_DELETED; }
 // 1 - (1 / LOAD_FACTOR_CONSTANT).
 static const int32_t LOAD_FACTOR_CONSTANT = 16;
 // Prevent integer overflow computing load factor
-__attribute__((unused))
-static const int32_t MAX_CAPACITY = 0x7fffffff / (LOAD_FACTOR_CONSTANT - 1);
+[[maybe_unused]] static const int32_t MAX_CAPACITY =
+    0x7fffffff / (LOAD_FACTOR_CONSTANT - 1);
 
 static bool is_overloaded(int32_t occupancy, int32_t capacity) {
     // Set the upper load threshold to be 15/16ths of the capacity.
@@ -40,8 +38,8 @@ static bool time_to_rebuild(int32_t ins_rm_count, int32_t capacity) {
            (ins_rm_count > capacity / (4 * LOAD_FACTOR_CONSTANT));
 }
 
-struct bucket *hyper_table::bucket_array_create(int32_t array_size) {
-    struct bucket *buckets = new bucket[array_size];
+bucket *hyper_table::bucket_array_create(int32_t array_size) {
+    bucket *buckets = new bucket[array_size];
     if (array_size < MIN_HT_CAPACITY) {
         return buckets;
     }
@@ -63,12 +61,10 @@ hyper_table *__cilkrts_local_hyper_table_alloc(void) {
     return new hyper_table(MIN_CAPACITY);
 }
 
-void local_hyper_table_free(hyper_table *table) {
-    delete table;
-}
+void local_hyper_table_free(hyper_table *table) { delete table; }
 
 void hyper_table::rebuild(int32_t new_capacity) {
-    struct bucket *old_buckets = buckets;
+    bucket *old_buckets = buckets;
     int32_t old_capacity = capacity;
     int32_t old_occupancy = occupancy;
 
@@ -85,9 +81,9 @@ void hyper_table::rebuild(int32_t new_capacity) {
     // table.
     for (int32_t i = 0; i < old_capacity; ++i) {
         if (is_valid(old_buckets[i].key)) {
-            bool success = insert_hyperobject(this, old_buckets[i]);
+            [[maybe_unused]] bool success =
+                insert_hyperobject(this, old_buckets[i]);
             assert(success && "Failed to insert when resizing table.");
-            (void)success;
         }
     }
 
@@ -100,13 +96,12 @@ void hyper_table::rebuild(int32_t new_capacity) {
 ///////////////////////////////////////////////////////////////////////////
 // Query, insert, and delete methods for the hash table.
 
-struct bucket *__cilkrts_find_hyperobject_hash(hyper_table *table,
-                                               uintptr_t key) {
+bucket *__cilkrts_find_hyperobject_hash(hyper_table *table, uintptr_t key) {
     int32_t capacity = table->capacity;
 
     // Target hash
     const index_t tgt = get_table_entry(capacity, key);
-    struct bucket *buckets = table->buckets;
+    bucket *buckets = table->buckets;
     // Start the probe at the target hash
     index_t i = tgt;
     do {
@@ -146,7 +141,7 @@ struct bucket *__cilkrts_find_hyperobject_hash(hyper_table *table,
 bool remove_hyperobject(hyper_table *table, uintptr_t key) noexcept {
     if (table->capacity < MIN_HT_CAPACITY) {
         // If the table is small enough, just scan the array.
-        struct bucket *buckets = table->buckets;
+        bucket *buckets = table->buckets;
         int32_t occupancy = table->occupancy;
 
         for (int32_t i = 0; i < occupancy; ++i) {
@@ -167,7 +162,7 @@ bool remove_hyperobject(hyper_table *table, uintptr_t key) noexcept {
     }
 
     // Find the key in the table.
-    struct bucket *entry = find_hyperobject(table, key);
+    bucket *entry = find_hyperobject(table, key);
 
     // If entry is NULL, the probe did not find the key.
     if (nullptr == entry)
@@ -188,9 +183,9 @@ bool remove_hyperobject(hyper_table *table, uintptr_t key) noexcept {
     return true;
 }
 
-bool insert_hyperobject(hyper_table *table, struct bucket b) noexcept {
+bool insert_hyperobject(hyper_table *table, bucket b) noexcept {
     int32_t capacity = table->capacity;
-    struct bucket *buckets = table->buckets;
+    bucket *buckets = table->buckets;
     if (capacity < MIN_HT_CAPACITY) {
         // If the table is small enough, just scan the array.
         int32_t occupancy = table->occupancy;
@@ -328,7 +323,7 @@ bool insert_hyperobject(hyper_table *table, struct bucket b) noexcept {
         }
 
         // Swap b with the current bucket.
-        struct bucket tmp = buckets[i];
+        bucket tmp = buckets[i];
         buckets[i] = b;
         b = tmp;
 
@@ -347,13 +342,10 @@ __reducer_base *__cilkrts_insert_new_view_0(hyper_table *table,
     void *new_view = cilk_aligned_alloc(64, round_size_to_alignment(64, size));
     __reducer_base *base = key->identity(new_view);
     // Insert the new view into the local hypertable.
-    struct bucket new_bucket = {
-        .key = (uintptr_t)key,
-        .data = { .view = new_view, .extra = base }
-    };
-    bool success = insert_hyperobject(table, new_bucket);
+    bucket new_bucket = {.key = (uintptr_t)key,
+                         .data = {.view = new_view, .extra = base}};
+    [[maybe_unused]] bool success = insert_hyperobject(table, new_bucket);
     assert(success);
-    (void)success;
     // Return the base class subobject of the new view.
     return base;
 }
@@ -365,33 +357,27 @@ void *__cilkrts_insert_new_view_1(hyper_table *table, uintptr_t key,
         cilk_aligned_alloc(64, round_size_to_alignment(64, callbacks.size));
     callbacks.identity(new_view);
     // Insert the new view into the local hypertable.
-    struct bucket new_bucket = {
+    bucket new_bucket = {
         .key = (uintptr_t)key,
         // XXX check lifetime
-        .data = { .view = new_view, .extra = &callbacks.reduce }
-    };
-    bool success = insert_hyperobject(table, new_bucket);
+        .data = {.view = new_view, .extra = &callbacks.reduce}};
+    [[maybe_unused]] bool success = insert_hyperobject(table, new_bucket);
     assert(success);
-    (void)success;
     // Return the new view.
     return new_view;
 }
 
 void *__cilkrts_insert_new_view_2(hyper_table *table, uintptr_t key,
-                                  size_t size,
-                                  void (*identity)(void *),
-                                  void (*reduce)(void *, void *)) {
+                                  size_t size, __cilk_c_identity_fn *identity,
+                                  __cilk_c_reduce_fn *reduce) {
     // Create a new view and initialize it with the identity function.
     void *new_view = cilk_aligned_alloc(64, round_size_to_alignment(64, size));
     identity(new_view);
     // Insert the new view into the local hypertable.
-    struct bucket new_bucket = {
-        .key = (uintptr_t)key,
-        .data = { .view = new_view, .extra = reduce }
-    };
-    bool success = insert_hyperobject(table, new_bucket);
+    bucket new_bucket = {.key = (uintptr_t)key,
+                         .data = {.view = new_view, .extra = reduce}};
+    [[maybe_unused]] bool success = insert_hyperobject(table, new_bucket);
     assert(success);
-    (void)success;
     // Return the new view.
     return new_view;
 }
@@ -431,16 +417,16 @@ hyper_table *merge_two_hts(hyper_table *__restrict left,
 
     int32_t src_capacity =
         (src->capacity < MIN_HT_CAPACITY) ? src->occupancy : src->capacity;
-    struct bucket *src_buckets = src->buckets;
+    bucket *src_buckets = src->buckets;
     // Iterate over the contents of the source hyper_table.
     for (int32_t i = 0; i < src_capacity; ++i) {
-        struct bucket b = src_buckets[i];
+        bucket b = src_buckets[i];
         if (!is_valid(b.key))
             continue;
 
         // For each valid key in the source table, lookup that key in the
         // destination table.
-        struct bucket *dst_bucket = find_hyperobject(dst, b.key);
+        bucket *dst_bucket = find_hyperobject(dst, b.key);
 
         if (nullptr == dst_bucket) {
             // The destination table does not contain this key.  Insert the
@@ -467,24 +453,22 @@ hyper_table *merge_two_hts(hyper_table *__restrict left,
     return dst;
 }
 
-void bucket::reduce(bucket *left, bucket *right)
-{
+void bucket::reduce(bucket *left, bucket *right) {
     assert(left->data.extra.index() == right->data.extra.index());
     void *left_view = left->data.view, *right_view = right->data.view;
     if (std::holds_alternative<__reducer_base *>(left->data.extra)) {
         __reducer_base *leftmost =
-            static_cast<__reducer_base *>
-            (reinterpret_cast<void *>(left->key));
+            static_cast<__reducer_base *>(reinterpret_cast<void *>(left->key));
         __reducer_base *left_r = std::get<__reducer_base *>(left->data.extra);
         __reducer_base *right_r = std::get<__reducer_base *>(right->data.extra);
         leftmost->reduce(left_r, right_r);
         right_r->~__reducer_base();
-    } else if (std::holds_alternative<const __cilk_reduce_fn *>(left->data.extra)) {
-        (*std::get<const __cilk_reduce_fn *>(left->data.extra))
-            (left_view, right_view);
+    } else if (std::holds_alternative<const __cilk_reduce_fn *>(
+                   left->data.extra)) {
+        (*std::get<const __cilk_reduce_fn *>(left->data.extra))(left_view,
+                                                                right_view);
     } else {
-        std::get<void (*)(void *, void *)>(left->data.extra)
-            (left_view, right_view);
+        std::get<__cilk_c_reduce_fn *>(left->data.extra)(left_view, right_view);
     }
     right->data.extra = (__reducer_base *)nullptr;
     right->data.view = nullptr;

--- a/runtime/local-hypertable.h
+++ b/runtime/local-hypertable.h
@@ -2,12 +2,9 @@
 #define _LOCAL_HYPERTABLE_H
 
 #include "rts-config.h"
-
 #include "cilk/cilk_api.h"
 #include "cilk/reducer"
-
 #include "hyperobject_base.h"
-
 #include <cstdint>
 #include <cstdlib>
 
@@ -47,17 +44,12 @@ struct hyper_table {
     index_t capacity;
     int32_t occupancy;
     int32_t ins_rm_count;
-    struct bucket *buckets;
+    bucket *buckets;
     hyper_table(index_t capacity)
         : capacity(capacity), occupancy(0), ins_rm_count(0),
-          buckets(bucket_array_create(capacity))
-    {
-    }
-    ~hyper_table()
-    {
-        delete [] buckets;
-    }
-    static struct bucket *bucket_array_create(int32_t size);
+          buckets(bucket_array_create(capacity)) {}
+    ~hyper_table() { delete[] buckets; }
+    static bucket *bucket_array_create(int32_t size);
     void rebuild(int32_t size);
 };
 
@@ -69,7 +61,7 @@ void local_hyper_table_free(hyper_table *table);
 CHEETAH_INTERNAL
 bool remove_hyperobject(hyper_table *table, uintptr_t key) noexcept;
 CHEETAH_INTERNAL
-bool insert_hyperobject(hyper_table *table, struct bucket b) noexcept;
+bool insert_hyperobject(hyper_table *table, bucket b) noexcept;
 
 CHEETAH_INTERNAL
 hyper_table *merge_two_hts(hyper_table *__restrict left,
@@ -211,10 +203,10 @@ static inline bool continue_probe(index_t tgt, index_t hash, index_t idx) {
     return (idx - tgt) <= (idx - hash);
 }
 
-static inline struct bucket *
-find_hyperobject_linear(hyper_table *table, uintptr_t key) {
+static inline bucket *find_hyperobject_linear(hyper_table *table,
+                                              uintptr_t key) {
     // If the table is small enough, just scan the array.
-    struct bucket *buckets = table->buckets;
+    bucket *buckets = table->buckets;
     int32_t occupancy = table->occupancy;
 
     // Scan the array backwards, since inserts add new entries to
@@ -228,11 +220,9 @@ find_hyperobject_linear(hyper_table *table, uintptr_t key) {
 }
 
 CHEETAH_API
-struct bucket *__cilkrts_find_hyperobject_hash(hyper_table *table,
-                                               uintptr_t key);
+bucket *__cilkrts_find_hyperobject_hash(hyper_table *table, uintptr_t key);
 
-static inline struct bucket *find_hyperobject(hyper_table *table,
-                                              uintptr_t key) {
+static inline bucket *find_hyperobject(hyper_table *table, uintptr_t key) {
     bucket *b;
     if (table->capacity < MIN_HT_CAPACITY) {
         b = find_hyperobject_linear(table, key);
@@ -244,19 +234,19 @@ static inline struct bucket *find_hyperobject(hyper_table *table,
 
 CHEETAH_API
 __reducer_base *__cilkrts_insert_new_view_0(hyper_table *table,
-                                            struct __reducer_base *key)
-  __attribute__((nonnull, returns_nonnull));
+                                            __reducer_base *key)
+    __attribute__((nonnull, returns_nonnull));
 
 CHEETAH_API
 void *__cilkrts_insert_new_view_1(hyper_table *table, uintptr_t key,
                                   const __reducer_callbacks &callbacks)
-  __attribute__((nonnull, returns_nonnull));
+    __attribute__((nonnull, returns_nonnull));
 
 CHEETAH_API
 void *__cilkrts_insert_new_view_2(hyper_table *table, uintptr_t key,
                                   size_t size,
-                                  void (*identity)(void *),
-                                  void (*reduce)(void *, void *))
-  __attribute__((nonnull, returns_nonnull));
+                                  __cilk_c_identity_fn *identity,
+                                  __cilk_c_reduce_fn *reduce)
+    __attribute__((nonnull, returns_nonnull));
 
 #endif // _LOCAL_HYPERTABLE_H

--- a/runtime/local-reducer-api.cpp
+++ b/runtime/local-reducer-api.cpp
@@ -7,64 +7,51 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
-__reducer_base::__reducer_base()
-{
-  // This would be a great place to register the reducer,
-  // but doing so would break the equivalence between
-  // leftmost view and dynamic views.  The derived class
-  // identity operation would need to pass a flag to this
-  // constructor to suppress registration.
+__reducer_base::__reducer_base() {
+    // This would be a great place to register the reducer,
+    // but doing so would break the equivalence between
+    // leftmost view and dynamic views.  The derived class
+    // identity operation would need to pass a flag to this
+    // constructor to suppress registration.
 }
 
-__reducer_base::~__reducer_base()
-{
-}
+__reducer_base::~__reducer_base() {}
 
-static void reducer_register(struct bucket &b)
-    __CILKRTS_NOTHROW
-{
+static void reducer_register(bucket &b) __CILKRTS_NOTHROW {
     struct hyper_table *table =
         get_local_hyper_table(__cilkrts_get_tls_worker());
-    bool success = insert_hyperobject(table, b);
+    [[maybe_unused]] bool success = insert_hyperobject(table, b);
     CILK_ASSERT(success && "Failed to register reducer.");
-    (void)success;
 }
 
-void __cilkrts_reducer_register_0(__reducer_base *key)
-    __CILKRTS_NOTHROW
-{
-    struct bucket b {
+void __cilkrts_reducer_register_0(__reducer_base *key) __CILKRTS_NOTHROW {
+    bucket b{.key = (uintptr_t)key, .data = {.view = nullptr, .extra = key}};
+    reducer_register(b);
+}
+
+void __cilkrts_reducer_register_1(void *key,
+                                  __reducer_callbacks *cb) __CILKRTS_NOTHROW {
+    bucket b{
         .key = (uintptr_t)key,
-        .data = { .view = nullptr, .extra = key }
+        .data = {.view = key, .extra = &cb->reduce},
     };
     reducer_register(b);
 }
 
-void __cilkrts_reducer_register_1(void *key, __reducer_callbacks *cb)
-    __CILKRTS_NOTHROW
-{
-    struct bucket b {
+void __cilkrts_reducer_register_2(void *key, __cilk_c_reduce_fn *reduce)
+    __CILKRTS_NOTHROW {
+    bucket b{
         .key = (uintptr_t)key,
-        .data = { .view = key, .extra = &cb->reduce },
-    };
-    reducer_register(b);
-}
-
-void __cilkrts_reducer_register_2(void *key, void (*reduce)(void *, void *))
-    __CILKRTS_NOTHROW
-{
-    struct bucket b {
-        .key = (uintptr_t)key,
-        .data = { .view = key, .extra = reduce },
+        .data = {.view = key, .extra = reduce},
     };
     reducer_register(b);
 }
 
 void __cilkrts_reducer_unregister(void *key) noexcept {
     if (struct hyper_table *table = get_hyper_table()) {
-        bool success = remove_hyperobject(table, (uintptr_t)key);
-        /* CILK_ASSERT(success && "Failed to unregister reducer."); */
-        (void)success;
+        [[maybe_unused]] bool success =
+            remove_hyperobject(table, (uintptr_t)key);
+        // CILK_ASSERT(success && "Failed to unregister reducer.");
     }
 }
 
@@ -74,7 +61,7 @@ CHEETAH_INTERNAL
 __reducer_base *internal_reducer_lookup(__cilkrts_worker *w,
                                         __reducer_base *key) {
     struct hyper_table *table = get_local_hyper_table(w);
-    struct bucket *b = find_hyperobject(table, (uintptr_t)key);
+    bucket *b = find_hyperobject(table, (uintptr_t)key);
     if (__builtin_expect(!!b, true)) {
         CILK_ASSERT_POINTER_EQUAL(key, (void *)b->key);
         // Return the existing view.
@@ -87,6 +74,5 @@ __reducer_base *internal_reducer_lookup(__cilkrts_worker *w,
 CHEETAH_INTERNAL
 void internal_reducer_remove(__cilkrts_worker *w, void *key) {
     struct hyper_table *table = get_local_hyper_table(w);
-    bool success = remove_hyperobject(table, (uintptr_t)key);
-    (void)success;
+    [[maybe_unused]] bool success = remove_hyperobject(table, (uintptr_t)key);
 }

--- a/runtime/local.h
+++ b/runtime/local.h
@@ -14,7 +14,7 @@ enum __cilkrts_worker_state : unsigned char {
 };
 
 struct __attribute__((visibility("hidden"))) local_state {
-    struct __cilkrts_stack_frame **shadow_stack;
+    __cilkrts_stack_frame **shadow_stack;
 
     __cilkrts_worker_state state;
     bool provably_good_steal;
@@ -26,11 +26,11 @@ struct __attribute__((visibility("hidden"))) local_state {
     jmpbuf rts_ctx;
     hyper_table *lht;
     hyper_table *rht;
-    struct cilk_fiber_pool fiber_pool;
-    struct cilk_im_desc im_desc;
-    struct sched_stats stats;
+    cilk_fiber_pool fiber_pool;
+    cilk_im_desc im_desc;
+    sched_stats stats;
 
-    void change_state(enum __cilkrts_worker_state to);
+    void change_state(__cilkrts_worker_state to);
 };
 
 #endif /* _CILK_LOCAL_H */

--- a/runtime/mutex.h
+++ b/runtime/mutex.h
@@ -1,15 +1,12 @@
 #ifndef _CILK_MUTEX_H
 #define _CILK_MUTEX_H
 
-// Forward declaration
-typedef union cilk_mutex cilk_mutex;
-
 // Includes
+#include "rts-config.h"
 #include <cerrno>
-#include <pthread.h>
 #include <cstdio>
 #include <cstdlib>
-#include "rts-config.h"
+#include <pthread.h>
 
 #ifndef __APPLE__
 #define USE_SPINLOCK 1

--- a/runtime/pedigree_ext.cpp
+++ b/runtime/pedigree_ext.cpp
@@ -35,10 +35,11 @@ void __cilkrts_extend_spawn(__cilkrts_worker *w, void **parent_extension,
         __pedigree_dprng_m_array[parent_frame->dprng_depth]);
 }
 
-void __cilkrts_extend_return_from_spawn(__cilkrts_worker *w, void **extension) {
+// TODO: Remove extension parameter?
+void __cilkrts_extend_return_from_spawn(__cilkrts_worker *w,
+                                        [[maybe_unused]] void **extension) {
     // Free the pedigree frame.
     pop_pedigree_frame(w);
-    (void)extension; // TODO: Remove the parameter?
 }
 
 void __cilkrts_extend_sync(void **extension) {

--- a/runtime/personality.cpp
+++ b/runtime/personality.cpp
@@ -18,10 +18,9 @@ static struct closure_exception exception_reducer;
 
 typedef _Unwind_Reason_Code (*__personality_routine)(
     int version, _Unwind_Action actions, uint64_t exception_class,
-    struct _Unwind_Exception *exception_object,
-    struct _Unwind_Context *context);
+    _Unwind_Exception *exception_object, _Unwind_Context *context);
 
-static char *get_cfa(struct _Unwind_Context *context) {
+static char *get_cfa(_Unwind_Context *context) {
     /* _Unwind_GetCFA is originally a gcc extension.  FreeBSD has its
        own library without that extension. */
 #if defined(__linux__) || (defined(__APPLE__) && defined(__MACH__))
@@ -55,14 +54,14 @@ __reducer_base *closure_exception::identity(void *v) {
 
 // Reduce method for the exception reducer.
 void closure_exception::reduce(__reducer_base *l, __reducer_base *r) {
-    struct closure_exception *lex = static_cast<struct closure_exception *>(l);
-    struct closure_exception *rex = static_cast<struct closure_exception *>(r);
+    closure_exception *lex = static_cast<closure_exception *>(l);
+    closure_exception *rex = static_cast<closure_exception *>(r);
     if (lex->exn == nullptr) {
         lex->exn = rex->exn;
         rex->exn = nullptr;
     }
     if (rex->exn != nullptr) {
-        _Unwind_DeleteException((struct _Unwind_Exception *)(rex->exn));
+        _Unwind_DeleteException((_Unwind_Exception *)(rex->exn));
         rex->exn = nullptr;
     }
     // Use right-holder logic for reraise_cfa, parent_rsp, and throwing_fiber.
@@ -76,27 +75,25 @@ void closure_exception::reduce(__reducer_base *l, __reducer_base *r) {
 
 // Get the current view of the exception-reducer state, creating a new view if
 // none exists.
-struct closure_exception *get_exception_reducer(__cilkrts_worker *w) noexcept {
-    return
-        static_cast<struct closure_exception *>
-        (internal_reducer_lookup(w, &exception_reducer));
+closure_exception *get_exception_reducer(__cilkrts_worker *w) noexcept {
+    return static_cast<closure_exception *>(
+        internal_reducer_lookup(w, &exception_reducer));
 }
 
 // Try to get the current view of the exception-reducer state, but return NULL
 // if no view exists.
-struct closure_exception *
-get_exception_reducer_or_null(__cilkrts_worker *w) noexcept {
+closure_exception *get_exception_reducer_or_null(__cilkrts_worker *w) noexcept {
     void *key = (void *)(&exception_reducer);
-    struct hyper_table *table = get_local_hyper_table_or_null(w);
+    hyper_table *table = get_local_hyper_table_or_null(w);
     if (nullptr == table)
         return nullptr;
 
-    struct bucket *b = find_hyperobject(table, (uintptr_t)key);
+    bucket *b = find_hyperobject(table, (uintptr_t)key);
     if (b) {
         CILK_ASSERT_POINTER_EQUAL(key, (void *)b->key);
         // Return the existing view.
         __reducer_base *base = std::get<__reducer_base *>(b->data.extra);
-        return static_cast<struct closure_exception *>(base);
+        return static_cast<closure_exception *>(base);
     }
     // No view was found.  Don't create a new reducer view; just return NULL.
     return nullptr;
@@ -104,7 +101,7 @@ get_exception_reducer_or_null(__cilkrts_worker *w) noexcept {
 
 // Destroy the current view of the exception-reducer state.
 void clear_exception_reducer(__cilkrts_worker *w,
-                             struct closure_exception *exn_r) noexcept {
+                             closure_exception *exn_r) noexcept {
     CILK_ASSERT_NULL(exn_r->throwing_fiber);
     free(exn_r);
     internal_reducer_remove(w, &exception_reducer);
@@ -118,7 +115,7 @@ void clear_exception_reducer(__cilkrts_worker *w,
 // local variables in the caller from being disrupted by the setjmp.
 __attribute__((noinline)) static void
 sync_in_personality(__cilkrts_worker *w, __cilkrts_stack_frame *sf,
-                    struct _Unwind_Exception *ue_header) {
+                    _Unwind_Exception *ue_header) {
     worker_id self = w->self;
     BusyClosure *busy = w->g->busy;
     // save floating point state
@@ -126,7 +123,7 @@ sync_in_personality(__cilkrts_worker *w, __cilkrts_stack_frame *sf,
 
     if (__builtin_setjmp(sf->ctx) == 0) {
         // set closure_exception
-        struct closure_exception *exn_r = get_exception_reducer(w);
+        closure_exception *exn_r = get_exception_reducer(w);
         exn_r->exn = (char *)ue_header;
 
         BusyClosure::lock_self(busy, self);
@@ -177,9 +174,9 @@ uncilkify(global_state *g, __cilkrts_stack_frame *sf) {
 
 // Custom routine to resume handling an exception after leaving a cilkified
 // region.
-static void
-resume_from_last_frame(__cilkrts_worker *w, __cilkrts_stack_frame *sf,
-                 struct _Unwind_Exception *ue_header) {
+static void resume_from_last_frame(__cilkrts_worker *w,
+                                   __cilkrts_stack_frame *sf,
+                                   _Unwind_Exception *ue_header) {
     cilkrts_alert(CFRAME, "resume_from_last_frame %p", (void *)sf);
     CILK_ASSERT(CHECK_CILK_FRAME_MAGIC(w->g, sf));
     // WHEN_CILK_DEBUG(sf->magic = ~CILK_STACKFRAME_MAGIC);
@@ -195,11 +192,10 @@ resume_from_last_frame(__cilkrts_worker *w, __cilkrts_stack_frame *sf,
     __builtin_unreachable();
 }
 
-extern "C"
-_Unwind_Reason_Code __cilk_personality_internal(
+extern "C" _Unwind_Reason_Code __cilk_personality_internal(
     __personality_routine std_lib_personality, int version,
     _Unwind_Action actions, uint64_t exception_class,
-    struct _Unwind_Exception *ue_header, struct _Unwind_Context *context) {
+    _Unwind_Exception *ue_header, _Unwind_Context *context) {
 
     // If called from outside a Cilkified region --- i.e., after the personality
     // function leaves the last __cilkrts_stack_frame --- then just use
@@ -208,7 +204,7 @@ _Unwind_Reason_Code __cilk_personality_internal(
         return std_lib_personality(version, actions, exception_class, ue_header,
                                    context);
 
-    struct cilk_fiber *fh = __cilkrts_tls.fh;
+    cilk_fiber *fh = __cilkrts_tls.fh;
     __cilkrts_worker *w = fh->worker;
     CILK_ASSERT_POINTER_EQUAL(w, __cilkrts_get_tls_worker());
     __cilkrts_stack_frame *sf = fh->current_stack_frame;
@@ -218,9 +214,8 @@ _Unwind_Reason_Code __cilk_personality_internal(
         return std_lib_personality(version, actions, exception_class, ue_header,
                                    context);
     } else if (actions & _UA_CLEANUP_PHASE) {
-        cilkrts_alert(EXCEPT,
-                      "cilk_personality called %p  CFA %p\n", (void *)sf,
-                      (void *)get_cfa(context));
+        cilkrts_alert(EXCEPT, "cilk_personality called %p  CFA %p\n",
+                      (void *)sf, (void *)get_cfa(context));
 
         if (sf->flags & CILK_FRAME_UNSYNCHED) {
             sync_in_personality(w, sf, ue_header);
@@ -234,7 +229,7 @@ _Unwind_Reason_Code __cilk_personality_internal(
         sf->flags &= ~CILK_FRAME_THROWING;
 
         // Get the saved exception state, if it exists.
-        struct closure_exception *exn_r = get_exception_reducer_or_null(w);
+        closure_exception *exn_r = get_exception_reducer_or_null(w);
 
         // Check for a reraised exception, and determine whether to skip
         // performing __cilkrts_leave_frame.
@@ -242,7 +237,8 @@ _Unwind_Reason_Code __cilk_personality_internal(
         bool skip_leaveframe = false;
         if (exn_r != nullptr) {
             in_reraised_cfa = (exn_r->reraise_cfa == (char *)get_cfa(context));
-            skip_leaveframe = ((exn_r->reraise_cfa != nullptr) && !in_reraised_cfa);
+            skip_leaveframe =
+                ((exn_r->reraise_cfa != nullptr) && !in_reraised_cfa);
         }
         if (in_reraised_cfa) {
             exn_r->reraise_cfa = nullptr;
@@ -253,8 +249,7 @@ _Unwind_Reason_Code __cilk_personality_internal(
         if ((exn_r != nullptr) && (exn_r->exn != nullptr) &&
             (exn_r->exn != (char *)ue_header)) {
 
-            struct _Unwind_Exception *exn =
-                    (struct _Unwind_Exception *)(exn_r->exn);
+            _Unwind_Exception *exn = (_Unwind_Exception *)(exn_r->exn);
             exn_r->exn = nullptr;
             cilkrts_alert(EXCEPT,
                           "cilk_personality calling RaiseException %p\n",

--- a/runtime/sched_stats.cpp
+++ b/runtime/sched_stats.cpp
@@ -1,15 +1,14 @@
-#include <cinttypes>
-#include <cstdio>
-#include <time.h>
 #include "cilk-internal.h"
 #include "debug.h"
 #include "global.h"
-#include "internal-malloc-impl.h"
 #include "local.h"
 #include "sched_stats.h"
+#include <cinttypes>
+#include <cstdio>
+#include <time.h>
 
 #if SCHED_STATS
-static const char *enum_to_str(enum timing_type t) {
+static const char *enum_to_str(timing_type t) {
     switch (t) {
     case INTERVAL_WORK:
         return "working";
@@ -30,8 +29,7 @@ static const char *enum_to_str(enum timing_type t) {
     }
 }
 
-__attribute__((unused)) static inline double
-micro_sec_to_sec(double micro_sec) {
+[[maybe_unused]] static inline double micro_sec_to_sec(double micro_sec) {
     return micro_sec / 1000000.0;
 }
 
@@ -51,7 +49,7 @@ static inline uint64_t end_time() {
 
 int nr_events = 32;
 
-void cilk_global_sched_stats_init(struct global_sched_stats *s) {
+void cilk_global_sched_stats_init(global_sched_stats *s) {
     s->boss_waiting = 0;
     s->boss_wait_count = 0;
     s->boss_begin = 0;
@@ -67,7 +65,7 @@ void cilk_global_sched_stats_init(struct global_sched_stats *s) {
     }
 }
 
-void cilk_sched_stats_init(struct sched_stats *s) {
+void cilk_sched_stats_init(sched_stats *s) {
     for (int i = 0; i < NUMBER_OF_STATS; ++i) {
         s->begin[i] = 0;
         s->end[i] = 0;
@@ -82,7 +80,7 @@ void cilk_sched_stats_init(struct sched_stats *s) {
 
 void cilk_start_timing(__cilkrts_worker *w, enum timing_type t) {
     if (w) {
-        struct sched_stats *s = &(w->l->stats);
+        sched_stats *s = &(w->l->stats);
         CILK_ASSERT(s->begin[t] == 0);
         s->end[t] = 0;
         s->begin[t] = begin_time();
@@ -91,7 +89,7 @@ void cilk_start_timing(__cilkrts_worker *w, enum timing_type t) {
 
 void cilk_stop_timing(__cilkrts_worker *w, enum timing_type t) {
     if (w) {
-        struct sched_stats *s = &(w->l->stats);
+        sched_stats *s = &(w->l->stats);
         CILK_ASSERT(s->end[t] == 0);
         s->end[t] = end_time();
         CILK_ASSERT(s->end[t] >= s->begin[t]);
@@ -104,7 +102,7 @@ void cilk_stop_timing(__cilkrts_worker *w, enum timing_type t) {
 void cilk_switch_timing(__cilkrts_worker *w, enum timing_type t1,
                         enum timing_type t2) {
     if (w) {
-        struct sched_stats *s = &(w->l->stats);
+        sched_stats *s = &(w->l->stats);
         // Stop timer t1
         CILK_ASSERT(s->end[t1] == 0);
         s->end[t1] = end_time();
@@ -122,21 +120,21 @@ void cilk_switch_timing(__cilkrts_worker *w, enum timing_type t1,
 
 void cilk_drop_timing(__cilkrts_worker *w, enum timing_type t) {
     if (w) {
-        struct sched_stats *s = &(w->l->stats);
+        sched_stats *s = &(w->l->stats);
         CILK_ASSERT(s->begin[t] != 0);
         s->begin[t] = 0;
     }
 }
 
-void cilk_boss_start_timing(struct global_state *g) {
-    struct global_sched_stats *s = &(g->stats);
+void cilk_boss_start_timing(global_state *g) {
+    global_sched_stats *s = &(g->stats);
     CILK_ASSERT(s->boss_begin == 0);
     s->boss_begin = begin_time();
     s->boss_end = 0;
 }
 
-void cilk_boss_stop_timing(struct global_state *g) {
-    struct global_sched_stats *s = &(g->stats);
+void cilk_boss_stop_timing(global_state *g) {
+    global_sched_stats *s = &(g->stats);
     CILK_ASSERT(s->boss_end == 0);
     s->boss_end = end_time();
     CILK_ASSERT(s->boss_end >= s->boss_begin);
@@ -148,14 +146,14 @@ void cilk_boss_stop_timing(struct global_state *g) {
     s->exit_time = 0;
 }
 
-void cilk_exit_worker_timing(struct global_state *g) {
-    struct global_sched_stats *s = &(g->stats);
+void cilk_exit_worker_timing(global_state *g) {
+    global_sched_stats *s = &(g->stats);
     CILK_ASSERT(s->exit_time == 0);
     s->exit_time = begin_time();
 }
 
 static void sched_stats_reset_worker(__cilkrts_worker *w,
-                                     void *data __attribute__((unused))) {
+                                     [[maybe_unused]] void *data) {
     local_state *l = w->l;
     for (int t = 0; t < NUMBER_OF_STATS; t++) {
         l->stats.time[t] = 0;
@@ -198,7 +196,7 @@ static void sched_stats_print_worker(__cilkrts_worker *w, void *data) {
     fprintf(fp, "\n");
 }
 
-void cilk_sched_stats_print(struct global_state *g) {
+void cilk_sched_stats_print(global_state *g) {
     for (int t = 0; t < NUMBER_OF_STATS; t++) {
         g->stats.time[t] = 0.0;
         g->stats.count[t] = 0;
@@ -218,8 +216,9 @@ void cilk_sched_stats_print(struct global_state *g) {
         g->stats.boss_wait_count = 0;
     }
     fprintf(stderr, COL_DESC, "");
-    for (int t = 0; t < NUMBER_OF_STATS; t++) {
-        fprintf(stderr, HDR_DESC, enum_to_str(t), "count");
+    for (int t = 0; t < NUMBER_OF_STATS; ++t) {
+        fprintf(stderr, HDR_DESC, enum_to_str(static_cast<timing_type>(t)),
+                "count");
     }
     fprintf(stderr, COUNT_HDR_DESC, "steals");
     fprintf(stderr, COUNT_HDR_DESC, "reposses");

--- a/runtime/sched_stats.h
+++ b/runtime/sched_stats.h
@@ -4,7 +4,8 @@
 #include "rts-config.h"
 #include <cstdint>
 
-typedef struct __cilkrts_worker __cilkrts_worker;
+struct __cilkrts_worker;
+struct global_state;
 
 #define SCHED_STATS CILK_STATS
 
@@ -48,9 +49,9 @@ struct global_sched_stats {
 
 #if SCHED_STATS
 CHEETAH_INTERNAL
-void cilk_global_sched_stats_init(struct global_sched_stats *s);
+void cilk_global_sched_stats_init(global_sched_stats *s);
 CHEETAH_INTERNAL
-void cilk_sched_stats_init(struct sched_stats *s);
+void cilk_sched_stats_init(sched_stats *s);
 CHEETAH_INTERNAL
 void cilk_start_timing(__cilkrts_worker *w, enum timing_type t);
 CHEETAH_INTERNAL
@@ -61,13 +62,13 @@ void cilk_switch_timing(__cilkrts_worker *w, enum timing_type t1,
 CHEETAH_INTERNAL
 void cilk_drop_timing(__cilkrts_worker *w, enum timing_type t);
 CHEETAH_INTERNAL
-void cilk_boss_start_timing(struct global_state *g);
+void cilk_boss_start_timing(global_state *g);
 CHEETAH_INTERNAL
-void cilk_boss_stop_timing(struct global_state *g);
+void cilk_boss_stop_timing(global_state *g);
 CHEETAH_INTERNAL
-void cilk_exit_worker_timing(struct global_state *g);
+void cilk_exit_worker_timing(global_state *g);
 CHEETAH_INTERNAL
-void cilk_sched_stats_print(struct global_state *g);
+void cilk_sched_stats_print(global_state *g);
 // void cilk_reset_timing(__cilkrts_worker *w, enum timing_type t);
 // FIXME: should have a header file that's user-code interfacing
 // void __cilkrts_reset_timing(); // user-code facing

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -42,7 +42,7 @@ struct __cilkrts_status __cilkrts_status = {
   .use_extension = false
 };
 
-__thread struct __cilkrts_tls __cilkrts_tls = {
+thread_local struct __cilkrts_tls __cilkrts_tls = {
   
   // TLS pointer to the current worker structure.
   .worker = &default_worker,
@@ -75,7 +75,7 @@ static unsigned int get_rand(unsigned int state) {
     return state >> 16;
 }
 
-void local_state::change_state(enum __cilkrts_worker_state s) {
+void local_state::change_state(__cilkrts_worker_state s) {
     /* TODO: Update statistics based on state change. */
     CILK_ASSERT(state != s);
     state = s;
@@ -139,7 +139,7 @@ static void signal_immediate_exception_to_all(__cilkrts_worker *const w) {
 
 static void setup_for_execution(__cilkrts_worker *w, Closure *t) {
     cilkrts_alert(SCHED, "(setup_for_execution) closure %p", (void *)t);
-    struct cilk_fiber *fh = t->fiber;
+    cilk_fiber *fh = t->fiber;
     fh->worker = w;
     t->set_status(CLOSURE_RUNNING);
 
@@ -193,7 +193,7 @@ static void setup_for_sync(__cilkrts_worker *w, worker_id self, Closure *t) {
     //         (void *)t->fiber);
     __cilkrts_set_synced(t->frame);
 
-    struct cilk_fiber *fh = t->fiber;
+    cilk_fiber *fh = t->fiber;
     __cilkrts_tls.fh = fh;
     t->frame->fh = fh;
     fh->worker = w;
@@ -261,9 +261,8 @@ void __cilkrts_set_return(__cilkrts_worker *const w) {
     CILK_ASSERT((t->frame->flags & CILK_FRAME_DETACHED) == 0);
 
     Closure *call_parent = t->call_parent;
-    Closure *t1 = BusyClosure::xtract(busy, self, self);
+    [[maybe_unused]] Closure *t1 = BusyClosure::xtract(busy, self, self);
 
-    USE_UNUSED(t1);
     CILK_ASSERT_POINTER_EQUAL(t, t1);
     CILK_ASSERT(__cilkrts_stolen(t->frame));
 
@@ -661,7 +660,7 @@ void __cilkrts_exception_handler(__cilkrts_worker *w, char *exn) {
         if (nullptr != exn) {
             // The spawned child is throwing an exception.  Save that exception
             // object for later processing.
-            struct closure_exception *exn_r = get_exception_reducer(w);
+            closure_exception *exn_r = get_exception_reducer(w);
             exn_r->exn = exn;
             t->exception_pending = true;
         }
@@ -864,7 +863,7 @@ static Closure *promote_child(__cilkrts_stack_frame **head, BusyClosure *busy,
     /***
      * Register this child, which sets up its sibling links.
      * We do this here instead of in finish_promote, because we must setup
-     * the sib links for the new child before its pointer escapses.
+     * the sib links for the new child before its pointer escapes.
      ***/
     spawn_parent->add_child(self, spawn_child);
 
@@ -920,8 +919,8 @@ static Closure *extract_top_spawning_closure(__cilkrts_stack_frame **head,
                                              Closure *cl, worker_id self,
                                              worker_id victim_id) {
     Closure *res = nullptr, *child;
-    struct cilk_fiber *parent_fiber = cl->fiber;
-    struct cilk_fiber *parent_ext_fiber = cl->ext_fiber;
+    cilk_fiber *parent_fiber = cl->fiber;
+    cilk_fiber *parent_ext_fiber = cl->ext_fiber;
 
     BusyClosure::assert_ownership(busy, self, victim_id);
     cl->assert_ownership(self);
@@ -1054,7 +1053,7 @@ void longjmp_to_user_code(__cilkrts_worker *w, Closure *t) {
     CILK_ASSERT(w->l->state == WORKER_RUN);
 
     __cilkrts_stack_frame *sf = t->frame;
-    struct cilk_fiber *fiber = t->fiber;
+    cilk_fiber *fiber = t->fiber;
 
     CILK_ASSERT(sf && fiber);
 
@@ -1083,8 +1082,8 @@ void longjmp_to_user_code(__cilkrts_worker *w, Closure *t) {
         if (t == g->root_closure && *initialized == false) {
             *initialized = true;
         } else {
-            void *new_rsp = sysdep_reset_stack_for_resume(fiber, sf);
-            USE_UNUSED(new_rsp);
+            [[maybe_unused]] void *new_rsp =
+                sysdep_reset_stack_for_resume(fiber, sf);
             CILK_ASSERT_POINTER_EQUAL(SP(sf), new_rsp);
             if (USE_EXTENSION) {
                 w->extension = sf->extension;
@@ -1097,7 +1096,7 @@ void longjmp_to_user_code(__cilkrts_worker *w, Closure *t) {
     if (!__cilkrts_throwing(sf)) {
         sanitizer_start_switch_fiber(fiber);
     } else {
-        struct closure_exception *exn_r = get_exception_reducer_or_null(w);
+        closure_exception *exn_r = get_exception_reducer_or_null(w);
         if (exn_r) {
             sanitizer_start_switch_fiber(exn_r->throwing_fiber);
         }
@@ -1118,7 +1117,7 @@ CHEETAH_INTERNAL_NORETURN void longjmp_to_runtime(__cilkrts_worker *w) {
 
 /* This function implements a sync in user code, including the implicit
    sync at the end of a function.  It is only called if compiled code
-   finds CILK_FRAME_UNSYCHED is set.  It returns SYNC_READY if there
+   finds CILK_FRAME_UNSYNCHED is set.  It returns SYNC_READY if there
    are no children and execution can continue.  Otherwise it returns
    SYNC_NOT_READY to suspend the frame. */
 int Cilk_sync(__cilkrts_worker *const w, __cilkrts_stack_frame *frame) {
@@ -1190,7 +1189,7 @@ int Cilk_sync(__cilkrts_worker *const w, __cilkrts_stack_frame *frame) {
         if (!__cilkrts_throwing(frame)) {
             sanitizer_start_switch_fiber(t->fiber);
         } else {
-            struct closure_exception *exn_r = get_exception_reducer_or_null(w);
+            closure_exception *exn_r = get_exception_reducer_or_null(w);
             if (exn_r) {
                 sanitizer_start_switch_fiber(exn_r->throwing_fiber);
             }
@@ -1203,7 +1202,7 @@ int Cilk_sync(__cilkrts_worker *const w, __cilkrts_stack_frame *frame) {
 
 static void do_what_it_says(BusyClosure *busy, __cilkrts_worker *w,
                             worker_id self, Closure *t) {
-    __cilkrts_stack_frame *f;
+    [[maybe_unused]] __cilkrts_stack_frame *f;
     local_state *l = w->l;
 
     do {
@@ -1217,7 +1216,6 @@ static void do_what_it_says(BusyClosure *busy, __cilkrts_worker *w,
             cilkrts_alert(SCHED, "(do_what_it_says) resume_sf = %p",
                           (void *)f);
             CILK_ASSERT(f);
-            USE_UNUSED(f);
 
             // MUST unlock the closure before locking the queue
             // (rule A in file PROTOCOLS)
@@ -1408,8 +1406,8 @@ void worker_scheduler(__cilkrts_worker *w, history_t *const history) {
                 rts->disengaged_sentinel.load(std::memory_order_relaxed);
             uint32_t disengaged = GET_DISENGAGED(disengaged_sentinel);
             uint32_t stealable = nworkers - disengaged;
-            __attribute__((unused))
-            uint32_t sentinel = recent_sentinel_count / SENTINEL_COUNT_HISTORY;
+            [[maybe_unused]] uint32_t sentinel =
+                recent_sentinel_count / SENTINEL_COUNT_HISTORY;
 
             if (__builtin_expect(stealable == 1, false))
                 // If this worker detects only 1 stealable worker, then its the
@@ -1418,8 +1416,7 @@ void worker_scheduler(__cilkrts_worker *w, history_t *const history) {
 
 #else // ENABLE_THIEF_SLEEP
             uint32_t stealable = nworkers;
-            __attribute__((unused))
-            uint32_t sentinel = nworkers / 2;
+            [[maybe_unused]] uint32_t sentinel = nworkers / 2;
 #endif // ENABLE_THIEF_SLEEP
 #ifndef __APPLE__
             uint32_t lg_sentinel = sentinel == 0 ? 1
@@ -1474,7 +1471,7 @@ void worker_scheduler(__cilkrts_worker *w, history_t *const history) {
                 // Add some delay to the time a worker takes between steal
                 // attempts.  On a variety of systems, this delay seems to
                 // improve parallel performance of Cilk computations where
-                // workers spend a signficant amount of time stealing.
+                // workers spend a significant amount of time stealing.
                 //
                 // The computation for the delay is heuristic, based on the
                 // following:
@@ -1663,10 +1660,9 @@ void Closure::suspend(BusyClosure *busy, worker_id self) {
 
     change_status(CLOSURE_RUNNING, CLOSURE_SUSPENDED);
 
-    Closure *cl1 = BusyClosure::xtract(busy, self, self);
+    [[maybe_unused]] Closure *cl1 = BusyClosure::xtract(busy, self, self);
 
     CILK_ASSERT_POINTER_EQUAL(this, cl1);
-    USE_UNUSED(cl1);
 }
 
 void Closure::suspend_victim(BusyClosure *busy, worker_id thief_id,
@@ -1678,9 +1674,9 @@ void Closure::suspend_victim(BusyClosure *busy, worker_id thief_id,
 
     change_status(CLOSURE_RUNNING, CLOSURE_SUSPENDED);
 
-    Closure *cl1 = BusyClosure::xtract(busy, thief_id, victim_id);
+    [[maybe_unused]] Closure *cl1 =
+        BusyClosure::xtract(busy, thief_id, victim_id);
     CILK_ASSERT_POINTER_EQUAL(this, cl1);
-    USE_UNUSED(cl1);
 }
 
 void Closure::remove_callee() {
@@ -1713,9 +1709,7 @@ void Closure::add_callee(Closure *new_callee) {
  * child gets unlinked at a time, and one child gets to modify the steal
  * tree at a time.
  ***/
-void Closure::remove_child(worker_id self, Closure *child) {
-    (void)self; // unused if assertions disabled
-
+void Closure::remove_child([[maybe_unused]] worker_id self, Closure *child) {
     CILK_ASSERT(child);
     CILK_ASSERT_POINTER_EQUAL(this, child->spawn_parent);
 
@@ -1747,12 +1741,10 @@ void Closure::remove_child(worker_id self, Closure *child) {
  * we are holding.  The pointer to new right most child is not visible
  * to anyone yet, so we don't need to lock that, either.
  ***/
-void Closure::add_child(worker_id self, Closure *child) {
-    (void)self; // unused if assertions disabled
-
-    /* ANGE: w must have the lock on parent */
+void Closure::add_child([[maybe_unused]] worker_id self, Closure *child) {
+    // w must have the lock on parent
     assert_ownership(self);
-    /* ANGE: w must NOT have the lock on child */
+    // w must NOT have the lock on child
     child->assert_alienation(self);
 
     // setup sib links between parent's right most child and the new child
@@ -1866,9 +1858,9 @@ Closure *Closure::create(__cilkrts_worker * w,
     return new(closure) Closure(sf);
 }
 
-/* ANGE: destroy the closure and internally free it (put back to global
+/* Destroy the closure and internally free it (put back to global
    pool) */
-void Closure::destroy(Closure *cl, struct __cilkrts_worker *const w) {
+void Closure::destroy(Closure *cl, __cilkrts_worker *const w) {
     cilkrts_alert(CLOSURE, "Deallocate closure %p", (void *)cl);
     cl->~Closure();
     cilk_internal_free(w, cl, sizeof(*cl), IM_CLOSURE);
@@ -1876,7 +1868,7 @@ void Closure::destroy(Closure *cl, struct __cilkrts_worker *const w) {
 
 /* Destroy the closure and internally free it (put back to global pool), after
    workers have been terminated. */
-void Closure::destroy(Closure *cl, struct global_state *const g) {
+void Closure::destroy(Closure *cl, global_state *const g) {
     cilkrts_alert(CLOSURE, "Deallocate closure %p", (void *)cl);
     cl->~Closure();
     cilk_internal_free_global(g, cl, sizeof(*cl), IM_CLOSURE);
@@ -1896,8 +1888,7 @@ void Closure::lock(worker_id self) {
     }
 }
 
-void Closure::unlock(worker_id self) {
-    (void)self; // unused if assertions disabled
+void Closure::unlock([[maybe_unused]] worker_id self) {
     checkmagic();
     assert_ownership(self);
     mutex_owner.store(NO_WORKER, std::memory_order_release);

--- a/runtime/scheduler.h
+++ b/runtime/scheduler.h
@@ -4,6 +4,8 @@
 #include "closure.h"
 #include "efficiency.h"
 
+struct worker_args;
+
 #define SYNC_READY 0
 #define SYNC_NOT_READY 1
 

--- a/runtime/worker.h
+++ b/runtime/worker.h
@@ -1,6 +1,7 @@
 #ifndef _CILK_WORKER_H
 #define _CILK_WORKER_H
 
+#include "rts-config.h"
 #include <atomic>
 #include <cstdint>
 
@@ -13,20 +14,22 @@ typedef uint32_t worker_id;
 #define WORKER_ID_FMT PRIu32
 #define NO_WORKER worker_id(0xffffffffu)
 
-struct __cilkrts_worker {
+// This alignment reduces false sharing induced by hardware prefetchers on some
+// systems, such as Intel CPUs.
+struct alignas(1024) __cilkrts_worker {
     // Worker id, a small integer
     worker_id self;
 
     // 4 byte hole on 64 bit systems
 
     // Current hyperobject table
-    struct hyper_table *hyper_table;
+    hyper_table *hyper_table;
 
     // Global state of the runtime system, opaque to the client.
-    struct global_state *g;
+    global_state *g;
 
     // Additional per-worker state hidden from the client.
-    struct local_state *l;
+    local_state *l;
 
     // Cache line boundary on 64 bit systems with 64 byte cache lines
 
@@ -37,17 +40,13 @@ struct __cilkrts_worker {
     // T, H, and E pointers in the THE protocol.
     // T and E are frequently accessed and should be in a hot cache line.
     // H could be moved elsewhere because it is only touched when stealing.
-    std::atomic<struct __cilkrts_stack_frame **> tail;
-    std::atomic<struct __cilkrts_stack_frame **> exc
-      __attribute__((aligned(CILK_CACHE_LINE)));
-    std::atomic<struct __cilkrts_stack_frame **> head
-      __attribute__((aligned(CILK_CACHE_LINE)));
+    std::atomic<__cilkrts_stack_frame **> tail;
+    alignas(CILK_CACHE_LINE) std::atomic<__cilkrts_stack_frame **> exc;
+    alignas(CILK_CACHE_LINE) std::atomic<__cilkrts_stack_frame **> head;
 
     // Limit of the Lazy Task Queue, to detect queue overflow (debug only)
-    struct __cilkrts_stack_frame **ltq_limit;
+    __cilkrts_stack_frame **ltq_limit;
 
-} __attribute__((aligned(1024))); // This alignment reduces false sharing
-                                  // induced by hardware prefetchers on some
-                                  // systems, such as Intel CPUs.
+};
 
 #endif /* _CILK_WORKER_H */

--- a/runtime/worker_coord.h
+++ b/runtime/worker_coord.h
@@ -1,6 +1,8 @@
 #ifndef _WORKER_COORD_H
 #define _WORKER_COORD_H
 
+#include "rts-config.h"
+
 // Routines for coordinating workers, specifically, putting workers to sleep and
 // waking workers when execution enters and leaves cilkified regions.
 

--- a/runtime/worker_sleep.cpp
+++ b/runtime/worker_sleep.cpp
@@ -1,11 +1,11 @@
 #include "cilk-internal.h"
 #include "efficiency.h"
 #include "global.h"
+#include "local.h"
 #include "rts-config.h"
 #include "sched_stats.h"
 #include "worker_coord.h"
 #include <atomic>
-#include <climits>
 #include <cstdint>
 #include <time.h>
 
@@ -35,7 +35,7 @@
 
 // Threshold for number of consecutive failed steal attempts to try disengaging
 // this worker.  Must be a multiple of SENTINEL_THRESHOLD and a power of 2.
-#define DISENGAGE_THRESHOLD HISTORY_THRESHOLD * SENTINEL_THRESHOLD
+#define DISENGAGE_THRESHOLD HISTORY_THRESHOLD *SENTINEL_THRESHOLD
 
 uint64_t global_state::gettime_fast(void) {
     // __builtin_readcyclecounter triggers "illegal instruction" errors on ARM64
@@ -173,20 +173,19 @@ get_scaled_elapsed(unsigned int elapsed) {
 
 // If steal attempts found work, update histories as appropriate and possibly
 // reengage workers.
-unsigned int
-global_state::maybe_reengage_workers(worker_id self,
-                       unsigned int nworkers, __cilkrts_worker *const w,
-                       unsigned int fails,
-                       unsigned int *const sample_threshold,
-                       history_sample_t *const inefficient_history,
-                       history_sample_t *const efficient_history,
-                       unsigned int *const sentinel_count_history,
-                       unsigned int *const sentinel_count_history_tail,
-                       unsigned int *const recent_sentinel_count) {
+unsigned int global_state::maybe_reengage_workers(
+    worker_id self, unsigned int nworkers,
+    [[maybe_unused]] __cilkrts_worker *const w, unsigned int fails,
+    unsigned int *const sample_threshold,
+    history_sample_t *const inefficient_history,
+    history_sample_t *const efficient_history,
+    unsigned int *const sentinel_count_history,
+    unsigned int *const sentinel_count_history_tail,
+    unsigned int *const recent_sentinel_count) {
 #if !ENABLE_THIEF_SLEEP
     return 0;
 #endif
-    (void)w; // unused if scheduling stats not enabled
+    // NOTE: The worker pointer is unused if scheduling stats are not enabled.
 
     if (fails >= SENTINEL_THRESHOLD) {
         // This thief is no longer a sentinel.  Decrement the number of
@@ -284,8 +283,8 @@ global_state::maybe_reengage_workers(worker_id self,
 }
 
 #if ENABLE_THIEF_SLEEP
-// Attempt to disengage this thief thread.  The __cilkrts_worker parameter is only
-// used for debugging.
+// Attempt to disengage this thief thread.  The __cilkrts_worker parameter is
+// only used for debugging.
 bool global_state::maybe_disengage_thief(worker_id self,
                                          unsigned int nworkers) {
     // Check the number of active and sentinel workers, and disengage this
@@ -317,18 +316,16 @@ bool global_state::maybe_disengage_thief(worker_id self,
 
 // If steal attempts did not find work, update histories as appropriate and
 // possibly disengage this worker.
-unsigned int
-global_state::handle_failed_steal_attempts(worker_id self,
-                             unsigned int nworkers, const unsigned int NAP_THRESHOLD,
-                             __cilkrts_worker *const w,
-                             unsigned int fails,
-                             unsigned int *const sample_threshold,
-                             history_sample_t *const inefficient_history,
-                             history_sample_t *const efficient_history,
-                             unsigned int *const sentinel_count_history,
-                             unsigned int *const sentinel_count_history_tail,
-                             unsigned int *const recent_sentinel_count) {
-    (void)w; // only used when timing is enabled
+unsigned int global_state::handle_failed_steal_attempts(
+    worker_id self, unsigned int nworkers, const unsigned int NAP_THRESHOLD,
+    [[maybe_unused]] __cilkrts_worker *const w, unsigned int fails,
+    unsigned int *const sample_threshold,
+    history_sample_t *const inefficient_history,
+    history_sample_t *const efficient_history,
+    unsigned int *const sentinel_count_history,
+    unsigned int *const sentinel_count_history_tail,
+    unsigned int *const recent_sentinel_count) {
+    // worker is only used when timing is enabled
 
     const bool is_boss = (0 == self);
     // Threshold for number of failed steal attempts to put this thief to sleep
@@ -350,7 +347,8 @@ global_state::handle_failed_steal_attempts(worker_id self,
             // Prevent the fail count from exceeding this maximum, so we don't
             // have to worry about the fail count overflowing.
             fails = MAX_FAILS;
-            const struct timespec sleeptime = {.tv_sec = 0, .tv_nsec = SLEEP_NSEC};
+            const struct timespec sleeptime = {.tv_sec = 0,
+                                               .tv_nsec = SLEEP_NSEC};
             nanosleep(&sleeptime, nullptr);
         } else {
 #if ENABLE_THIEF_SLEEP
@@ -386,8 +384,7 @@ global_state::handle_failed_steal_attempts(worker_id self,
             history_sample_t my_inefficient_history = *inefficient_history;
             my_inefficient_history = (my_inefficient_history >> 1) |
                                      (curr_ineff << (HISTORY_LENGTH - 1));
-            int32_t ineff_steps =
-                __builtin_popcount(my_inefficient_history);
+            int32_t ineff_steps = __builtin_popcount(my_inefficient_history);
             *inefficient_history = my_inefficient_history;
 
 #endif
@@ -485,21 +482,19 @@ global_state::handle_failed_steal_attempts(worker_id self,
     return fails;
 }
 
-unsigned int global_state::go_to_sleep_maybe(worker_id self,
-                                      unsigned int nworkers,
-                                      const unsigned int NAP_THRESHOLD,
-                                      __cilkrts_worker *const w,
-                                      Closure *const t, unsigned int fails,
-                                      unsigned int *const sample_threshold,
-                                      history_sample_t *const inefficient_history,
-                                      history_sample_t *const efficient_history,
-                                      unsigned int *const sentinel_count_history,
-                                      unsigned int *const sentinel_count_history_tail,
-                                      unsigned int *const recent_sentinel_count) {
+unsigned int global_state::go_to_sleep_maybe(
+    worker_id self, unsigned int nworkers, const unsigned int NAP_THRESHOLD,
+    __cilkrts_worker *const w, Closure *const t, unsigned int fails,
+    unsigned int *const sample_threshold,
+    history_sample_t *const inefficient_history,
+    history_sample_t *const efficient_history,
+    unsigned int *const sentinel_count_history,
+    unsigned int *const sentinel_count_history_tail,
+    unsigned int *const recent_sentinel_count) {
     if (t) {
         return maybe_reengage_workers(
-            self, nworkers, w, fails, sample_threshold,
-            inefficient_history, efficient_history, sentinel_count_history,
+            self, nworkers, w, fails, sample_threshold, inefficient_history,
+            efficient_history, sentinel_count_history,
             sentinel_count_history_tail, recent_sentinel_count);
     } else {
         return handle_failed_steal_attempts(


### PR DESCRIPTION
… memory allocations.

This PR makes makes various syntactic changes to try to clean up and simplify the codebase, including the following:
- Remove unnecessary uses of `struct` and `enum`.  These aren't necessary in C++ the way they often are in C, and removing these keywords makes reduces the code and makes it easier to modify or extend those types in the future.  The existing code is also inconsistent in how it uses these keywords, so this change makes the codebase more consistent.
- Use standard C++ keywords, including `alignas`, `alignof`, and `thread_local`.
- Use the `[[maybe_unused]]` attribute to mark variables, functions, and parameters that might not be used.
- Replace some calls to `malloc`, `calloc`, and `free` with `new` and `delete`.
- Remove some unnecessary forward declarations.
- Add `__cilk_c_identity_fn` and `__cilk_c_reduce_fn` type definitions for C-style reducers.
- Update the formatting using `clang-format`.

These changes shouldn't impact functionality, but they should make the codebase easier to maintain and work with.