### PR TITLE
Make some headers more explicitly C++-only

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,7 +4,7 @@ set(cilk_header_files
   cilk/cilk_stub.h
   cilk/holder
   cilk/opadd_reducer
-  cilk/ostream_reducer.h
+  cilk/ostream_reducer
   cilk/reducer)
 
 set(output_dir ${CHEETAH_OUTPUT_DIR}/include)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -2,7 +2,7 @@ set(cilk_header_files
   cilk/cilk.h
   cilk/cilk_api.h
   cilk/cilk_stub.h
-  cilk/holder.h
+  cilk/holder
   cilk/opadd_reducer.h
   cilk/ostream_reducer.h
   cilk/reducer)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -3,7 +3,7 @@ set(cilk_header_files
   cilk/cilk_api.h
   cilk/cilk_stub.h
   cilk/holder
-  cilk/opadd_reducer.h
+  cilk/opadd_reducer
   cilk/ostream_reducer.h
   cilk/reducer)
 

--- a/include/cilk/cilk.h
+++ b/include/cilk/cilk.h
@@ -1,11 +1,15 @@
 #ifndef _CILK_H
 #define  _CILK_H
 
+#if __cilk < 301
+
 #define cilk_spawn _Cilk_spawn
 #define cilk_sync  _Cilk_sync
 #define cilk_for   _Cilk_for
 #define cilk_scope   _Cilk_scope
 
 #define cilk_reducer _Hyperobject
+
+#endif
 
 #endif /* _CILK_H */

--- a/include/cilk/holder
+++ b/include/cilk/holder
@@ -1,8 +1,6 @@
 #ifndef _HOLDER_H
 #define _HOLDER_H
 
-#ifdef __cplusplus
-
 #include <type_traits>
 
 namespace cilk {
@@ -16,10 +14,8 @@ template <typename A> static void reduce(void *left, void *right) {
 }
 
 template <typename A>
-using holder = A _Hyperobject(init<A>, reduce<A>);
+using holder = A cilk_reducer(init<A>, reduce<A>);
 
 } // namespace cilk
-
-#endif // __cplusplus
 
 #endif // _HOLDER_H

--- a/include/cilk/opadd_reducer
+++ b/include/cilk/opadd_reducer
@@ -1,8 +1,6 @@
 #ifndef _OPADD_REDUCER_H
 #define _OPADD_REDUCER_H
 
-#ifdef __cplusplus
-
 namespace cilk {
 
 template <typename T> static void zero(void *v) {
@@ -13,10 +11,8 @@ template <typename T> static void plus(void *l, void *r) {
     *static_cast<T *>(l) += *static_cast<T *>(r);
 }
 
-template <typename T> using opadd_reducer = T _Hyperobject(zero<T>, plus<T>);
+template <typename T> using opadd_reducer = T cilk_reducer(zero<T>, plus<T>);
 
 } // namespace cilk
-
-#endif // #ifdef __cplusplus
 
 #endif // _OPADD_REDUCER_H

--- a/include/cilk/ostream_reducer
+++ b/include/cilk/ostream_reducer
@@ -1,8 +1,6 @@
 #ifndef _OSTREAM_REDUCER_H
 #define _OSTREAM_REDUCER_H
 
-#ifdef __cplusplus
-
 #include <ostream>
 #include <sstream>
 
@@ -64,11 +62,9 @@ public:
 
 template<typename Char, typename Traits = std::char_traits<Char>>
   using ostream_reducer = ostream_view<Char, Traits>
-    _Hyperobject(&ostream_view<Char, std::char_traits<Char>>::identity,
-                 &ostream_view<Char, std::char_traits<Char>>::reduce);
+    cilk_reducer(&ostream_view<Char, Traits>::identity,
+                 &ostream_view<Char, Traits>::reduce);
 
 } // namespace cilk
-
-#endif // __cplusplus
 
 #endif // _OSTREAM_REDUCER_H


### PR DESCRIPTION
Make some headers more explicitly C++-only, renaming to drop the .h suffix and removing `#ifdef __cplusplus`.

Make cilk.h do nothing if `__cilk` is at least 301, the version introducing keyword support for the names beginning with `cilk_`.

This requires corresponding changes to cilktools and smallapps, which are ready.