### PR TITLE
Use index [4] instead of [3] to save MXCSR in case cf-protection is enabled

### DIFF
--- a/runtime/jmpbuf.h
+++ b/runtime/jmpbuf.h
@@ -27,7 +27,9 @@ typedef void *jmpbuf[JMPBUF_SIZE];
 
 #if defined __i386__ || defined __x86_64__
 // We use an otherwise unused entry in the jmpbuf to store MXCSR
-#define JMPBUF_MXCSR(ctx) (ctx)[3]
+// [0], [1], [2] hold fp, pc, sp.
+// When cf-protection is enabled, [3] holds the shadow stack.
+#define JMPBUF_MXCSR(ctx) (ctx)[4]
 /**
  * @brief Get MXCSR from jump buffer in__cilkrts_stack_frame.  X86 and X86_64
  * only.


### PR DESCRIPTION
On x86 (at least) cf-protection causes `builtin_setjmp` to save the shadow stack pointer in index 3 of the five word buffer.  Move the saved MXCSR to index 4.