### PR TITLE
Fix crash when deallocating extension fiber

### DIFF
--- a/cmake/Modules/AddCheetah.cmake
+++ b/cmake/Modules/AddCheetah.cmake
@@ -501,7 +501,6 @@ function(add_cheetah_bitcode name)
     else()
       set(COMPONENT_OPTION COMPONENT ${libname})
     endif()
-    set(output_file_${libname} ${output_name_${libname}}.bc)
     # Add compile command for bitcode file.
     add_library(${libname}_compile OBJECT ${LIB_SOURCES})
     target_include_directories(${libname}_compile PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/runtime/init.cpp
+++ b/runtime/init.cpp
@@ -762,7 +762,7 @@ CHEETAH_INTERNAL CHEETAH_COLD void __cilkrts_shutdown(global_state *g) {
 
     // Deallocate the root closure and its fiber
     cilk_fiber_deallocate_global(g, g->root_closure->fiber);
-    if (USE_EXTENSION)
+    if (USE_EXTENSION && g->root_closure->ext_fiber != nullptr)
         cilk_fiber_deallocate_global(g, g->root_closure->ext_fiber);
     Closure::destroy(g->root_closure, g);
 


### PR DESCRIPTION
This PR fixes a crash when deallocating fibers for the runtime's extension mechanism, specifically, when the program linked to the runtime contains no Cilk code.