### PR TITLE
Delay fiber free after suspend in cilk_sync

### DIFF
--- a/runtime/init.cpp
+++ b/runtime/init.cpp
@@ -43,6 +43,7 @@ static local_state *worker_local_init(local_state *l, global_state *g) {
     l->returning = false;
     l->rand_next = 0; /* will be reset in scheduler loop */
     l->wake_val = 0;
+    l->abandoned = nullptr;
     l->lht = nullptr;
     l->rht = nullptr;
     cilk_sched_stats_init(&(l->stats));
@@ -52,7 +53,10 @@ static local_state *worker_local_init(local_state *l, global_state *g) {
 
 static void worker_local_destroy([[maybe_unused]] local_state *l,
                                  [[maybe_unused]] global_state *g) {
-    /* currently nothing to do here */
+    if (l->abandoned) {
+        cilk_fiber_deallocate_global(g, l->abandoned);
+        l->abandoned = nullptr;
+    }
 }
 
 static void busy_init(global_state *g) {

--- a/runtime/local.h
+++ b/runtime/local.h
@@ -22,6 +22,7 @@ struct __attribute__((visibility("hidden"))) local_state {
     bool returning;
     unsigned int rand_next;
     uint32_t wake_val;
+    cilk_fiber *abandoned;
 
     jmpbuf rts_ctx;
     hyper_table *lht;

--- a/runtime/personality.cpp
+++ b/runtime/personality.cpp
@@ -234,7 +234,7 @@ extern "C" _Unwind_Reason_Code __cilk_personality_internal(
         return std_lib_personality(version, actions, exception_class, ue_header,
                                    context);
     } else if (actions & _UA_CLEANUP_PHASE) {
-        cilkrts_alert(EXCEPT, "cilk_personality called %p  CFA %p\n",
+        cilkrts_alert(EXCEPT, "cilk_personality called %p  CFA %p",
                       (void *)sf, (void *)get_cfa(context));
 
         if (sf->flags & CILK_FRAME_UNSYNCHED) {

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -1147,7 +1147,11 @@ int Cilk_sync(__cilkrts_worker *const w, __cilkrts_stack_frame *frame) {
         cilkrts_alert(SYNC, "(Cilk_sync) Closure %p has outstanding children",
                       (void *)t);
         if (t->fiber) {
-            cilk_fiber_deallocate_to_pool(w, t->fiber);
+            // This fiber may still be in use by the runtime even though
+            // user code is done with it.
+            if (cilk_fiber *abandoned = w->l->abandoned)
+                cilk_fiber_deallocate_to_pool(w, abandoned);
+            w->l->abandoned = t->fiber;
         }
         if (USE_EXTENSION && t->ext_fiber) {
             cilk_fiber_deallocate_to_pool(w, t->ext_fiber);


### PR DESCRIPTION
The runtime code that suspends at a sync may be running on the fiber that is about to be freed.  Defer free until the runtime is definitely on another fiber.