### PR TITLE
[scheduler] Properly restore extension stack pointer after a sync.

### DIFF
--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -204,9 +204,9 @@ static void setup_for_sync(__cilkrts_worker *w, worker_id self, Closure *t) {
         // Set the worker's extension (analogous to updating the worker's stack
         // pointer).
         w->extension = t->frame->extension;
-        // Set the worker's extension stack to be the start of the saved
-        // extension fiber.
-        w->ext_stack = t->ext_fiber->get_stack_start();
+        // Set the worker's extension stack pointer to the current extension
+        // frame, at the bottom of that stack.
+        w->ext_stack = t->frame->extension;
     }
     t->orig_rsp = nullptr; // unset once we have sync-ed
 }


### PR DESCRIPTION
Fixes OpenCilk/opencilk-project#476