### PR TITLE
[scheduler] If the current extension frame is not on the worker's ext…

### DIFF
--- a/.github/workflows/small-cilkapps.yml
+++ b/.github/workflows/small-cilkapps.yml
@@ -70,3 +70,18 @@ jobs:
           CXX=$opencilkdir/bin/clang++ \
           EXTRA_CFLAGS="--opencilk-resource-dir=$cheetahdir" \
           EXTRA_LDFLAGS="--opencilk-resource-dir=$cheetahdir"
+    - name: make check pedigrees
+      shell: bash
+      run: |
+        cheetahdir="$(pwd)"/build
+        opencilkdir='${{ steps.build-opencilk.outputs.opencilk-builddir }}'
+        make_prefix=""
+        if [ "${{ runner.os }}" == "macOS" ]; then
+          # Use xcrun to build benchmarks on macOS.
+          make_prefix="xcrun"
+        fi
+        $make_prefix make -C smallapps check \
+          CC=$opencilkdir/bin/clang \
+          CXX=$opencilkdir/bin/clang++ \
+          EXTRA_CFLAGS="--opencilk-resource-dir=$cheetahdir -fopencilk-enable-pedigrees" \
+          EXTRA_LDFLAGS="--opencilk-resource-dir=$cheetahdir -fopencilk-enable-pedigrees"

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -201,12 +201,19 @@ static void setup_for_sync(__cilkrts_worker *w, worker_id self, Closure *t) {
 
     SP(t->frame) = (void *)t->orig_rsp;
     if (USE_EXTENSION) {
+        void *ext_frame = t->frame->extension;
         // Set the worker's extension (analogous to updating the worker's stack
         // pointer).
-        w->extension = t->frame->extension;
-        // Set the worker's extension stack pointer to the current extension
-        // frame, at the bottom of that stack.
-        w->ext_stack = t->frame->extension;
+        w->extension = ext_frame;
+        // Set the worker's extension stack pointer to the bottom of its view of
+        // the extension cactus stack.  If the current extension frame is on the
+        // worker's extension fiber, then it's at the bottom of that fiber, and
+        // the extension stack pointer should point to it.  Otherwise, there are
+        // no frames on that extension fiber, and the extension stack pointer
+        // should point to the start of that fiber.
+        w->ext_stack = t->ext_fiber->in_fiber(ext_frame)
+                           ? ext_frame
+                           : t->ext_fiber->get_stack_start();
     }
     t->orig_rsp = nullptr; // unset once we have sync-ed
 }


### PR DESCRIPTION
…ension fiber, set the worker's extension stack to point to the start of that fiber.

Fixes the follow-up issue reported in OpenCilk/opencilk-project#476